### PR TITLE
Performance optimization-- cache the encoding step

### DIFF
--- a/cached_encoding_event.go
+++ b/cached_encoding_event.go
@@ -21,10 +21,10 @@ func makeCachedEncodingEvent(evt Event) cachedEncodingEvent {
 
 func (evt cachedEncodingEvent) Encode() []byte {
 	evt.once.Do(func() {
-		var buff bytes.Buffer
-		enc := NewEncoder(&buff, false)
-		enc.Encode(evt)
-		evt.encoded = buff.Bytes()
+		buf := new(bytes.Buffer)
+		enc := NewEncoder(buf, false)
+		enc.Encode(evt.wrapped)
+		evt.encoded = buf.Bytes()
 	})
 
 	return evt.encoded

--- a/cached_encoding_event.go
+++ b/cached_encoding_event.go
@@ -1,0 +1,43 @@
+package eventsource
+
+import (
+	"bytes"
+	"sync"
+)
+
+type cachedEncodingEvent struct {
+	wrapped Event
+	once    *sync.Once
+	encoded []byte
+}
+
+func makeCachedEncodingEvent(evt Event) cachedEncodingEvent {
+	return cachedEncodingEvent{
+		wrapped: evt,
+		once:    new(sync.Once),
+		encoded: nil,
+	}
+}
+
+func (evt cachedEncodingEvent) Encode() []byte {
+	evt.once.Do(func() {
+		var buff bytes.Buffer
+		enc := NewEncoder(&buff, false)
+		enc.Encode(evt)
+		evt.encoded = buff.Bytes()
+	})
+
+	return evt.encoded
+}
+
+func (evt cachedEncodingEvent) Id() string {
+	return evt.wrapped.Id()
+}
+
+func (evt cachedEncodingEvent) Event() string {
+	return evt.wrapped.Event()
+}
+
+func (evt cachedEncodingEvent) Data() string {
+	return evt.wrapped.Data()
+}

--- a/encoder.go
+++ b/encoder.go
@@ -38,18 +38,26 @@ func NewEncoder(w io.Writer, compressed bool) *Encoder {
 // Encode writes an event in the format specified by the
 // server-sent events protocol.
 func (enc *Encoder) Encode(ev Event) error {
-	for _, field := range encFields {
-		prefix, value := field.prefix, field.value(ev)
-		if len(value) == 0 {
-			continue
-		}
-		value = strings.Replace(value, "\n", "\n"+prefix, -1)
-		if _, err := io.WriteString(enc.w, prefix+value+"\n"); err != nil {
+	if cev, ok := ev.(cachedEncodingEvent); ok {
+		data := cev.Encode()
+		if _, err := enc.w.Write(data); err != nil {
 			return fmt.Errorf("eventsource encode: %v", err)
 		}
-	}
-	if _, err := io.WriteString(enc.w, "\n"); err != nil {
-		return fmt.Errorf("eventsource encode: %v", err)
+	} else {
+
+		for _, field := range encFields {
+			prefix, value := field.prefix, field.value(ev)
+			if len(value) == 0 {
+				continue
+			}
+			value = strings.Replace(value, "\n", "\n"+prefix, -1)
+			if _, err := io.WriteString(enc.w, prefix+value+"\n"); err != nil {
+				return fmt.Errorf("eventsource encode: %v", err)
+			}
+		}
+		if _, err := io.WriteString(enc.w, "\n"); err != nil {
+			return fmt.Errorf("eventsource encode: %v", err)
+		}
 	}
 	if enc.compressed {
 		return enc.w.(*gzip.Writer).Flush()

--- a/server.go
+++ b/server.go
@@ -113,7 +113,7 @@ func (srv *Server) Register(channel string, repo Repository) {
 func (srv *Server) Publish(channels []string, ev Event) {
 	srv.pub <- &outbound{
 		channels: channels,
-		event:    ev,
+		event:    makeCachedEncodingEvent(ev),
 	}
 }
 


### PR DESCRIPTION
If there are many subscribers for an event, it may be more efficient to pre-compute the encoding.