### PR TITLE
Don't override http.Client checkRedirect on go1.8 or later

### DIFF
--- a/check_redirect.go
+++ b/check_redirect.go
@@ -1,0 +1,25 @@
+// +build !go1.8
+
+package eventsource
+
+import "net/http"
+
+func setCheckRedirect(c *http.Client) {
+   c.CheckRedirect = checkRedirect
+}
+
+// Go's http package doesn't copy headers across when it encounters
+// redirects so we need to do that manually.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+  if len(via) >= 10 {
+    return errors.New("stopped after 10 redirects")
+  }
+  for k, vv := range via[0].Header {
+    for _, v := range vv {
+      req.Header.Add(k, v)
+    }
+  }
+  return nil
+}
+
+f

--- a/check_redirect.go
+++ b/check_redirect.go
@@ -2,24 +2,25 @@
 
 package eventsource
 
-import "net/http"
+import (
+	"errors"
+	"net/http"
+)
 
 func setCheckRedirect(c *http.Client) {
-   c.CheckRedirect = checkRedirect
+	c.CheckRedirect = checkRedirect
 }
 
 // Go's http package doesn't copy headers across when it encounters
 // redirects so we need to do that manually.
 func checkRedirect(req *http.Request, via []*http.Request) error {
-  if len(via) >= 10 {
-    return errors.New("stopped after 10 redirects")
-  }
-  for k, vv := range via[0].Header {
-    for _, v := range vv {
-      req.Header.Add(k, v)
-    }
-  }
-  return nil
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	for k, vv := range via[0].Header {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	return nil
 }
-
-f

--- a/check_redirect_go1.8.go
+++ b/check_redirect_go1.8.go
@@ -1,0 +1,9 @@
+// +build go1.8
+
+package eventsource
+
+import "net/http"
+
+// On go1.8 we don't need to do anything because it will copy headers on redirects
+func setCheckRedirect(c *http.Client) {
+}


### PR DESCRIPTION
checkRedirect will replay headers on go1.8 or later so we don't need to
override it.  By not overriding it, we can avoid errors when running with the
race condition check.