### PR TITLE
Eliminate extra error messages on failed connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ jobs:
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circle-reports
           COMMON_GO_PACKAGES: >
-            gopkg.in/alecthomas/gometalinter.v2
             github.com/jstemmer/go-junit-report
+          GOLANGCI_LINT_VERSION: v1.9.1
 
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
-      - run: gometalinter.v2 --install
-      - run: gometalinter.v2 --disable gocyclo --disable golint --disable goconst --disable errcheck --disable maligned
+      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
+      - run: golangci-lint run
 
       - run: |
           mkdir -p $CIRCLE_TEST_REPORTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
-      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
-      - run: golangci-lint run
+      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- $GOLANGCI_LINT_VERSION
+      - run: ./bin/golangci-lint run
 
       - run: |
           mkdir -p $CIRCLE_TEST_REPORTS

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,9 +16,10 @@ linter-settings:
 
 issues:
   exclude:
-  - "(func|method|struct field|type|var) .* should be " # golint errors about variable names (don't want to fix them because they're in a public interface)
+  # gas
   - "G104: Errors unhandled." # Let errcheck handle these
   # golint
+  - "(func|method|struct field|type|var) .* should be " # golint errors about variable names (don't want to fix them because they're in a public interface)
   - "Comment on exported"
   - "exported .* should have comment or be unexported"
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+run:
+  deadline: 120s
+  tests: false
+
+linters:
+  enable-all: true
+  disable:
+  - gocyclo
+  - gofmt
+  - maligned
+  fast: false
+
+linter-settings:
+  gofmt:
+    simplify: false
+
+issues:
+  exclude:
+  - "(func|method|struct field|type|var) .* should be " # golint errors about variable names (don't want to fix them because they're in a public interface)
+  - "G104: Errors unhandled." # Let errcheck handle these
+  # golint
+  - "Comment on exported"
+  - "exported .* should have comment or be unexported"
+  exclude-use-default: false
+  max-same-issues: 1000
+  max-per-linter: 1000

--- a/decoder.go
+++ b/decoder.go
@@ -25,7 +25,7 @@ type Decoder struct {
 // NewDecoder returns a new Decoder instance that reads events
 // with the given io.Reader.
 func NewDecoder(r io.Reader) *Decoder {
-	dec := &Decoder{bufio.NewReader(newNormaliser(r))}
+	dec := &Decoder{Reader: bufio.NewReader(newNormaliser(r))}
 	return dec
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -32,7 +32,7 @@ func NewDecoder(r io.Reader) *Decoder {
 // Decode reads the next Event from a stream (and will block until one
 // comes in).
 // Graceful disconnects (between events) are indicated by an io.EOF error.
-// Any error occuring mid-event is considered non-graceful and will
+// Any error occurring mid-event is considered non-graceful and will
 // show up as some other error (most likely io.ErrUnexpectedEOF).
 func (dec *Decoder) Decode() (Event, error) {
 	// peek ahead before we start a new event so we can return EOFs

--- a/stream.go
+++ b/stream.go
@@ -91,7 +91,8 @@ func (stream *Stream) Close() {
 	})
 }
 
-func (stream *Stream) connect() (r io.ReadCloser, err error) {
+func (stream *Stream) connect() (io.ReadCloser, error) {
+	var err error
 	var resp *http.Response
 	stream.req.Header.Set("Cache-Control", "no-cache")
 	stream.req.Header.Set("Accept", "text/event-stream")
@@ -103,12 +104,12 @@ func (stream *Stream) connect() (r io.ReadCloser, err error) {
 	// All but the initial connection will need to regenerate the body
 	if stream.connections > 0 && req.GetBody != nil {
 		if req.Body, err = req.GetBody(); err != nil {
-			return
+			return nil, err
 		}
 	}
 
 	if resp, err = stream.c.Do(&req); err != nil {
-		return
+		return nil, err
 	}
 	stream.connections++
 	if resp.StatusCode != 200 {
@@ -118,10 +119,9 @@ func (stream *Stream) connect() (r io.ReadCloser, err error) {
 			Code:    resp.StatusCode,
 			Message: string(message),
 		}
-	} else {
-		r = resp.Body
+		return nil, err
 	}
-	return
+	return resp.Body, err
 }
 
 func (stream *Stream) stream(r io.ReadCloser) {

--- a/stream.go
+++ b/stream.go
@@ -61,7 +61,6 @@ func SubscribeWithRequest(lastEventId string, request *http.Request) (*Stream, e
 // control over the http client settings (timeouts, tls, etc)
 // If request.Body is set, then request.GetBody should also be set so that we can reissue the request
 func SubscribeWith(lastEventId string, client *http.Client, request *http.Request) (*Stream, error) {
-
 	// override checkRedirect to include headers before go1.8
 	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
 	setCheckRedirect(client)

--- a/stream.go
+++ b/stream.go
@@ -61,6 +61,11 @@ func SubscribeWithRequest(lastEventId string, request *http.Request) (*Stream, e
 // control over the http client settings (timeouts, tls, etc)
 // If request.Body is set, then request.GetBody should also be set so that we can reissue the request
 func SubscribeWith(lastEventId string, client *http.Client, request *http.Request) (*Stream, error) {
+
+	// override checkRedirect to include headers before go1.8
+	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
+	setCheckRedirect(client)
+
 	stream := &Stream{
 		c:           client,
 		req:         request,

--- a/stream.go
+++ b/stream.go
@@ -120,7 +120,7 @@ func (stream *Stream) connect() (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return resp.Body, err
+	return resp.Body, nil
 }
 
 func (stream *Stream) stream(r io.ReadCloser) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -207,7 +207,7 @@ func TestStreamCloseWhileReconnecting(t *testing.T) {
 	httpServer := httptest.NewServer(server.Handler(eventChannelName))
 
 	stream := mustSubscribe(t, httpServer.URL, "")
-	stream.setRetry(time.Hour)
+	stream.setRetry(time.Minute)
 	publishedEvent := &publication{id: "123"}
 	server.Publish([]string{eventChannelName}, publishedEvent)
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -207,7 +207,7 @@ func TestStreamCloseWhileReconnecting(t *testing.T) {
 	httpServer := httptest.NewServer(server.Handler(eventChannelName))
 
 	stream := mustSubscribe(t, httpServer.URL, "")
-	stream.setRetry(time.Minute)
+	stream.setRetry(time.Hour)
 	publishedEvent := &publication{id: "123"}
 	server.Publish([]string{eventChannelName}, publishedEvent)
 


### PR DESCRIPTION
Ensure that we don't expect the user to close the body for non-200 requests by closing it ourselves and not returning it.

Also run lint and clean up a few style issues noted by linter.