### PR TITLE
implement read timeout in EventSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 [![GoDoc](https://godoc.org/github.com/launchdarkly/eventsource?status.svg)](http://godoc.org/github.com/launchdarkly/eventsource)
 [![CircleCI](https://circleci.com/gh/launchdarkly/eventsource.svg?style=svg)](https://circleci.com/gh/launchdarkly/eventsource)
 
-
 # Eventsource
 
-Eventsource implements a  [Go](http://golang.org/) implementation of  client and server to allow streaming data one-way over a HTTP connection using the Server-Sent Events API http://dev.w3.org/html5/eventsource/
+Eventsource implements a [Go](http://golang.org/) implementation of  client and server to allow streaming data one-way over a HTTP connection using the Server-Sent Events API http://dev.w3.org/html5/eventsource/
+
+This is a fork of: https://github.com/donovanhide/eventsource
 
 ## Installation
 
-    go get github.com/donovanhide/eventsource
+    go get github.com/launchdarkly/eventsource
 
 ## Documentation
 
-* [Reference](http://godoc.org/github.com/eventsource/eventsource)
+* [Reference](http://godoc.org/github.com/launchdarkly/eventsource)
 
 ## License
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -22,10 +22,9 @@ var encoderTests = []struct {
 }
 
 func TestRoundTrip(t *testing.T) {
-	buf := new(bytes.Buffer)
-	enc := NewEncoder(buf, false)
-	dec := NewDecoder(buf)
 	for _, tt := range encoderTests {
+		buf := new(bytes.Buffer)
+		enc := NewEncoder(buf, false)
 		want := tt.event
 		if err := enc.Encode(want); err != nil {
 			t.Fatal(err)
@@ -33,6 +32,7 @@ func TestRoundTrip(t *testing.T) {
 		if buf.String() != tt.output {
 			t.Errorf("Expected: %s Got: %s", tt.output, buf.String())
 		}
+		dec := NewDecoder(buf, 0)
 		ev, err := dec.Decode()
 		if err != nil {
 			t.Fatal(err)

--- a/decoder.go
+++ b/decoder.go
@@ -30,7 +30,11 @@ type Decoder struct {
 func NewDecoder(r io.Reader, readTimeout time.Duration) *Decoder {
 	bufReader := bufio.NewReader(newNormaliser(r))
 	linesCh, errorCh := newLineStreamChannel(bufReader)
-	return &Decoder{linesCh, errorCh, readTimeout}
+	return &Decoder{
+		linesCh:     linesCh,
+		errorCh:     errorCh,
+		readTimeout: readTimeout,
+	}
 }
 
 // Decode reads the next Event from a stream (and will block until one

--- a/decoder.go
+++ b/decoder.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type publication struct {
@@ -19,14 +20,17 @@ func (s *publication) Retry() int64  { return s.retry }
 
 // A Decoder is capable of reading Events from a stream.
 type Decoder struct {
-	*bufio.Reader
+	linesCh     <-chan string
+	errorCh     <-chan error
+	readTimeout time.Duration
 }
 
 // NewDecoder returns a new Decoder instance that reads events
 // with the given io.Reader.
-func NewDecoder(r io.Reader) *Decoder {
-	dec := &Decoder{Reader: bufio.NewReader(newNormaliser(r))}
-	return dec
+func NewDecoder(r io.Reader, readTimeout time.Duration) *Decoder {
+	bufReader := bufio.NewReader(newNormaliser(r))
+	linesCh, errorCh := newLineStreamChannel(bufReader)
+	return &Decoder{linesCh, errorCh, readTimeout}
 }
 
 // Decode reads the next Event from a stream (and will block until one
@@ -35,49 +39,78 @@ func NewDecoder(r io.Reader) *Decoder {
 // Any error occurring mid-event is considered non-graceful and will
 // show up as some other error (most likely io.ErrUnexpectedEOF).
 func (dec *Decoder) Decode() (Event, error) {
-	// peek ahead before we start a new event so we can return EOFs
-	_, err := dec.Peek(1)
-	if err == io.ErrUnexpectedEOF {
-		err = io.EOF
-	}
-	if err != nil {
-		return nil, err
-	}
 	pub := new(publication)
 	inDecoding := false
+	var timeoutCh <-chan time.Time
+	if dec.readTimeout > 0 {
+		timeoutCh = time.After(dec.readTimeout)
+	}
+ReadLoop:
 	for {
-		line, err := dec.ReadString('\n')
-		if err != nil {
+		select {
+		case line := <-dec.linesCh:
+			if line == "\n" && inDecoding {
+				// the empty line signals the end of an event
+				break ReadLoop
+			} else if line == "\n" && !inDecoding {
+				// only a newline was sent, so we don't want to publish an empty event but try to read again
+				continue
+			}
+			line = strings.TrimSuffix(line, "\n")
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+			sections := strings.SplitN(line, ":", 2)
+			field, value := sections[0], ""
+			if len(sections) == 2 {
+				value = strings.TrimPrefix(sections[1], " ")
+			}
+			inDecoding = true
+			switch field {
+			case "event":
+				pub.event = value
+			case "data":
+				pub.data += value + "\n"
+			case "id":
+				pub.id = value
+			case "retry":
+				pub.retry, _ = strconv.ParseInt(value, 10, 64)
+			}
+		case err := <-dec.errorCh:
+			if err == io.ErrUnexpectedEOF && !inDecoding {
+				// if we're not in the middle of an event then just return EOF
+				err = io.EOF
+			} else if err == io.EOF && inDecoding {
+				// if we are in the middle of an event then EOF is unexpected
+				err = io.ErrUnexpectedEOF
+			}
 			return nil, err
-		}
-		if line == "\n" && inDecoding {
-			// the empty line signals the end of an event
-			break
-		} else if line == "\n" && !inDecoding {
-			// only a newline was sent, so we don't want to publish an empty event but try to read again
-			continue
-		}
-		line = strings.TrimSuffix(line, "\n")
-		if strings.HasPrefix(line, ":") {
-			continue
-		}
-		sections := strings.SplitN(line, ":", 2)
-		field, value := sections[0], ""
-		if len(sections) == 2 {
-			value = strings.TrimPrefix(sections[1], " ")
-		}
-		inDecoding = true
-		switch field {
-		case "event":
-			pub.event = value
-		case "data":
-			pub.data += value + "\n"
-		case "id":
-			pub.id = value
-		case "retry":
-			pub.retry, _ = strconv.ParseInt(value, 10, 64)
+		case <-timeoutCh:
+			return nil, ErrReadTimeout
 		}
 	}
 	pub.data = strings.TrimSuffix(pub.data, "\n")
 	return pub, nil
+}
+
+/**
+ * Returns a channel that will receive lines of text as they are read. On any error
+ * from the underlying reader, it stops and posts the error to a second channel.
+ */
+func newLineStreamChannel(r *bufio.Reader) (<-chan string, <-chan error) {
+	linesCh := make(chan string)
+	errorCh := make(chan error)
+	go func() {
+		defer close(linesCh)
+		defer close(errorCh)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				errorCh <- err
+				return
+			}
+			linesCh <- line
+		}
+	}()
+	return linesCh, errorCh
 }

--- a/decoder.go
+++ b/decoder.go
@@ -49,23 +49,19 @@ func (dec *Decoder) Decode() (Event, error) {
 	var timeoutCh <-chan time.Time
 	if dec.readTimeout > 0 {
 		timeoutTimer = time.NewTimer(dec.readTimeout)
+		defer timeoutTimer.Stop()
 		timeoutCh = timeoutTimer.C
-	}
-	resetTimeout := func(reset bool) {
-		if timeoutTimer != nil {
-			if !timeoutTimer.Stop() {
-				<-timeoutCh
-			}
-			if reset {
-				timeoutTimer.Reset(dec.readTimeout)
-			}
-		}
 	}
 ReadLoop:
 	for {
 		select {
 		case line := <-dec.linesCh:
-			resetTimeout(true)
+			if timeoutTimer != nil {
+				if !timeoutTimer.Stop() {
+					<-timeoutCh
+				}
+				timeoutTimer.Reset(dec.readTimeout)
+			}
 			if line == "\n" && inDecoding {
 				// the empty line signals the end of an event
 				break ReadLoop
@@ -94,7 +90,6 @@ ReadLoop:
 				pub.retry, _ = strconv.ParseInt(value, 10, 64)
 			}
 		case err := <-dec.errorCh:
-			resetTimeout(false)
 			if err == io.ErrUnexpectedEOF && !inDecoding {
 				// if we're not in the middle of an event then just return EOF
 				err = io.EOF

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -24,7 +24,7 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		decoder := NewDecoder(strings.NewReader(test.rawInput))
+		decoder := NewDecoder(strings.NewReader(test.rawInput), 0)
 		i := 0
 		for {
 			event, err := decoder.Decode()

--- a/stream.go
+++ b/stream.go
@@ -99,7 +99,8 @@ func SubscribeWith(lastEventID string, client *http.Client, request *http.Reques
 }
 
 // SubscribeWithClientAndRequestAndConfig is the same as SubscribeWith, but allows specifying optional parameters.
-func SubscribeWithClientAndRequestAndConfig(lastEventID string, client *http.Client, request *http.Request, config StreamConfig) (*Stream, error) {
+func SubscribeWithClientAndRequestAndConfig(lastEventID string, client *http.Client, request *http.Request,
+	config StreamConfig) (*Stream, error) {
 	// override checkRedirect to include headers before go1.8
 	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
 	setCheckRedirect(client)

--- a/stream.go
+++ b/stream.go
@@ -121,16 +121,6 @@ func StreamOptionLogger(logger Logger) StreamOption {
 	return loggerOption{logger: logger}
 }
 
-// StreamConfig provides optional configuration parameters for a stream.
-type StreamConfig struct {
-	// ReadTimeout is the maximum amount of time for the stream to wait for new data before
-	// restarting the connection. If zero, it will wait indefinitely.
-	ReadTimeout time.Duration
-	// InitialRetry is the initial reconnection delay that will be used if the stream does
-	// not specify a different interval. If zero, DefaultInitialRetry is used.
-	InitialRetry time.Duration
-}
-
 const (
 	// DefaultInitialRetry is the initial reconnection delay that will be used if no other
 	// value is specified.

--- a/stream_test.go
+++ b/stream_test.go
@@ -11,8 +11,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -300,9 +298,15 @@ ReadLoop:
 
 	httpServer.CloseClientConnections()
 
-	assert.Equal(t, 2, len(receivedEvents))
-	if assert.Equal(t, 1, len(receivedErrors)) {
-		assert.Equal(t, ErrReadTimeout, receivedErrors[0])
+	if len(receivedEvents) != 2 {
+		t.Errorf("Expected 2 events, received %d", len(receivedEvents))
+	}
+	if len(receivedErrors) != 1 {
+		t.Errorf("Expected 1 error, received %d", len(receivedErrors))
+	} else {
+		if receivedErrors[0] != ErrReadTimeout {
+			t.Errorf("Expected %s, received %s", ErrReadTimeout, receivedErrors[0])
+		}
 	}
 }
 


### PR DESCRIPTION
* A read timeout can now be specified for an EventSource. If that interval elapses without receiving the next line of text, it will consider the stream to have failed, emit a timeout error, and attempt to reconnect as it would for an I/O error. The default is still no timeout, as before.
* To set the read timeout, use the new type `StreamConfig`, and new constructor methods that take this type.
* `StreamConfig` also lets you set the initial retry delay. Previously, it was always 3 seconds.