### PR TITLE
undo breaking change to NewDecoder, add method with variadic options

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -32,7 +32,7 @@ func TestRoundTrip(t *testing.T) {
 		if buf.String() != tt.output {
 			t.Errorf("Expected: %s Got: %s", tt.output, buf.String())
 		}
-		dec := NewDecoder(buf, 0)
+		dec := NewDecoder(buf)
 		ev, err := dec.Decode()
 		if err != nil {
 			t.Fatal(err)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -24,7 +24,7 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		decoder := NewDecoder(strings.NewReader(test.rawInput), 0)
+		decoder := NewDecoder(strings.NewReader(test.rawInput))
 		i := 0
 		for {
 			event, err := decoder.Decode()

--- a/stream.go
+++ b/stream.go
@@ -271,7 +271,7 @@ NewStream:
 		errs := make(chan error)
 
 		if r != nil {
-			dec := NewDecoder(r, stream.readTimeout)
+			dec := NewDecoderWithOptions(r, DecoderOptionReadTimeout(stream.readTimeout))
 			go func() {
 				for {
 					ev, err := dec.Decode()


### PR DESCRIPTION
https://app.clubhouse.io/launchdarkly/story/41219/go-eventsource-fix-breaking-change-to-newdecoder