### PR TITLE
extend Stream to support backoff, jitter, and initial connection retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
+      - run: go get -t ./...
 
       - run: |
           mkdir -p $CIRCLE_TEST_REPORTS

--- a/retry_delay.go
+++ b/retry_delay.go
@@ -138,6 +138,6 @@ func (r *retryDelayStrategy) SetBaseDelay(baseDelay time.Duration) {
 	r.retryCount = 0
 }
 
-func (r *retryDelayStrategy) hasJitter() bool { // used only in tests
+func (r *retryDelayStrategy) hasJitter() bool { //nolint:megacheck // used only in tests
 	return r.jitter != nil
 }

--- a/retry_delay.go
+++ b/retry_delay.go
@@ -1,0 +1,139 @@
+package eventsource
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Encapsulation of configurable backoff/jitter behavior.
+//
+// - The system can either be in a "good" state or a "bad" state. The initial state is "bad"; the
+// caller is responsible for indicating when it transitions to "good". When we ask for a new retry
+// delay, that implies the state is now transitioning to "bad".
+//
+// - There is a configurable base delay, which can be changed at any time (if the SSE server sends
+// us a "retry:" directive).
+//
+// - There are optional strategies for applying backoff and jitter to the delay.
+//
+// This object is meant to be used from a single goroutine once it's been created; its methods are
+// not safe for concurrent use.
+type retryDelayStrategy struct {
+	baseDelay     time.Duration
+	backoff       backoffStrategy
+	jitter        jitterStrategy
+	resetInterval time.Duration
+	retryCount    int
+	goodSince     time.Time // nonzero only if the state is currently "good"
+}
+
+// Abstraction for backoff delay behavior.
+type backoffStrategy interface {
+	applyBackoff(baseDelay time.Duration, retryCount int) time.Duration
+}
+
+// Abstraction for delay jitter behavior.
+type jitterStrategy interface {
+	applyJitter(computedDelay time.Duration) time.Duration
+}
+
+type defaultBackoffStrategy struct {
+	maxDelay time.Duration
+}
+
+// Creates the default implementation of exponential backoff, which doubles the delay each time.
+func newDefaultBackoff(maxDelay time.Duration) backoffStrategy {
+	return defaultBackoffStrategy{maxDelay}
+}
+
+func (s defaultBackoffStrategy) applyBackoff(baseDelay time.Duration, retryCount int) time.Duration {
+	d := time.Duration(int64(baseDelay) * int64(math.Pow(2, float64(retryCount))))
+	if d > s.maxDelay {
+		return s.maxDelay
+	}
+	return d
+}
+
+type defaultJitterStrategy struct {
+	random *rand.Rand
+}
+
+// Creates the default implementation of jitter, which subtracts up to 50% from each delay.
+func newDefaultJitter(randSeed int64) jitterStrategy {
+	if randSeed <= 0 {
+		randSeed = time.Now().UnixNano()
+	}
+	return &defaultJitterStrategy{rand.New(rand.NewSource(randSeed))}
+}
+
+func (s *defaultJitterStrategy) applyJitter(computedDelay time.Duration) time.Duration {
+	// retryCount doesn't matter here - it's included in the int
+	jitter := time.Duration(s.random.Int63n(int64(computedDelay) / 2))
+	return computedDelay - jitter
+}
+
+//
+// - If backoff is enabled, there is also a configurable maximum delay; the delay will increase
+// exponentially up to the maximum. There is also a configurable "reset interval"; if the system
+// enters a "good" state and then at least that amount of time elapses, the delay is reset back to
+// the base (this avoids perpetually increasing delays in a situation where failures are rare).
+//
+// - If jitter is enabled, each computed delay is reduced pseudo-randomly by up to 50%.
+//
+// This object is meant to be used from a single goroutine once it's been created; its methods are
+// not safe for concurrent use.
+
+func newRetryDelayStrategy(
+	baseDelay time.Duration,
+	resetInterval time.Duration,
+	backoff backoffStrategy,
+	jitter jitterStrategy,
+) *retryDelayStrategy {
+	return &retryDelayStrategy{
+		baseDelay:     baseDelay,
+		resetInterval: resetInterval,
+		backoff:       backoff,
+		jitter:        jitter,
+	}
+}
+
+// NextRetryDelay computes the next retry interval. This also sets the current state to "bad".
+//
+// Note that currentTime is passed as a parameter instead of computed by this function to guarantee predictable
+// behavior in tests.
+func (r *retryDelayStrategy) NextRetryDelay(currentTime time.Time) time.Duration {
+	if !r.goodSince.IsZero() && r.resetInterval > 0 && (currentTime.Sub(r.goodSince) >= r.resetInterval) {
+		r.retryCount = 0
+	}
+	r.goodSince = time.Time{}
+	delay := r.baseDelay
+	if r.backoff != nil {
+		delay = r.backoff.applyBackoff(delay, r.retryCount)
+	}
+	r.retryCount++
+	if r.jitter != nil {
+		delay = r.jitter.applyJitter(delay)
+	}
+	return delay
+}
+
+// SetGoodSince marks the current state as "good" and records the time. See comments on the backoff type.
+func (r *retryDelayStrategy) SetGoodSince(goodSince time.Time) {
+	r.goodSince = goodSince
+}
+
+// SetBaseDelay changes the initial retry delay and resets the backoff (if any) so the next retry will use
+// that value.
+//
+// This is used to implement the optional SSE behavior where the server sends a "retry:" command to
+// set the base retry to a specific value. Note that we will still apply a jitter, if jitter is enabled,
+// and subsequent retries will still increase exponentially.
+func (r *retryDelayStrategy) SetBaseDelay(baseDelay time.Duration) {
+	r.baseDelay = baseDelay
+	r.retryCount = 0
+}
+
+func (r *retryDelayStrategy) hasJitter() bool { // used only in tests
+	return r.jitter != nil
+}

--- a/retry_delay_test.go
+++ b/retry_delay_test.go
@@ -1,0 +1,89 @@
+package eventsource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFixedRetryDelay(t *testing.T) {
+	d0 := time.Second * 10
+	r := newRetryDelayStrategy(d0, 0, nil, nil)
+	t0 := time.Now().Add(-time.Minute)
+	d1 := r.NextRetryDelay(t0)
+	d2 := r.NextRetryDelay(t0.Add(time.Second))
+	d3 := r.NextRetryDelay(t0.Add(time.Second * 2))
+	assert.Equal(t, d0, d1)
+	assert.Equal(t, d0, d2)
+	assert.Equal(t, d0, d3)
+}
+
+func TestBackoffWithoutJitter(t *testing.T) {
+	d0 := time.Second * 10
+	max := time.Minute
+	r := newRetryDelayStrategy(d0, 0, newDefaultBackoff(max), nil)
+	t0 := time.Now().Add(-time.Minute)
+	d1 := r.NextRetryDelay(t0)
+	d2 := r.NextRetryDelay(t0.Add(time.Second))
+	d3 := r.NextRetryDelay(t0.Add(time.Second * 2))
+	d4 := r.NextRetryDelay(t0.Add(time.Second * 3))
+	assert.Equal(t, d0, d1)
+	assert.Equal(t, d0*2, d2)
+	assert.Equal(t, d0*4, d3)
+	assert.Equal(t, max, d4)
+}
+
+func TestJitterWithoutBackoff(t *testing.T) {
+	d0 := time.Second
+	seed := int64(1000)
+	r := newRetryDelayStrategy(d0, 0, nil, newDefaultJitter(seed))
+	t0 := time.Now().Add(-time.Minute)
+	d1 := r.NextRetryDelay(t0)
+	d2 := r.NextRetryDelay(t0.Add(time.Second))
+	d3 := r.NextRetryDelay(t0.Add(time.Second * 2))
+	assert.Equal(t, time.Duration(985036673), d1) // these are the randomized values we expect from that fixed seed value
+	assert.Equal(t, time.Duration(925004285), d2)
+	assert.Equal(t, time.Duration(847349921), d3)
+}
+
+func TestJitterWithBackoff(t *testing.T) {
+	d0 := time.Second
+	max := time.Minute
+	seed := int64(1000)
+	r := newRetryDelayStrategy(d0, 0, newDefaultBackoff(max), newDefaultJitter(seed))
+	t0 := time.Now().Add(-time.Minute)
+	d1 := r.NextRetryDelay(t0)
+	d2 := r.NextRetryDelay(t0.Add(time.Second))
+	d3 := r.NextRetryDelay(t0.Add(time.Second * 2))
+	assert.Equal(t, time.Duration(985036673), d1) // these are the randomized values we expect from that fixed seed value
+	assert.Equal(t, time.Duration(1425004285), d2)
+	assert.Equal(t, time.Duration(3347349921), d3)
+}
+
+func TestBackoffResetInterval(t *testing.T) {
+	d0 := time.Second * 10
+	max := time.Minute
+	resetInterval := time.Second * 45
+	r := newRetryDelayStrategy(d0, resetInterval, newDefaultBackoff(max), nil)
+	t0 := time.Now().Add(-time.Minute)
+	r.SetGoodSince(t0)
+
+	t1 := t0.Add(time.Second)
+	d1 := r.NextRetryDelay(t1)
+	assert.Equal(t, d0, d1)
+
+	t2 := t1.Add(d1)
+	r.SetGoodSince(t2)
+
+	t3 := t2.Add(time.Second * 10)
+	d2 := r.NextRetryDelay(t3)
+	assert.Equal(t, d0*2, d2)
+
+	t4 := t3.Add(d2)
+	r.SetGoodSince(t4)
+
+	t5 := t4.Add(resetInterval)
+	d3 := r.NextRetryDelay(t5)
+	assert.Equal(t, d0, d3)
+}

--- a/retry_delay_test.go
+++ b/retry_delay_test.go
@@ -37,7 +37,7 @@ func TestBackoffWithoutJitter(t *testing.T) {
 func TestJitterWithoutBackoff(t *testing.T) {
 	d0 := time.Second
 	seed := int64(1000)
-	r := newRetryDelayStrategy(d0, 0, nil, newDefaultJitter(seed))
+	r := newRetryDelayStrategy(d0, 0, nil, newDefaultJitter(0.5, seed))
 	t0 := time.Now().Add(-time.Minute)
 	d1 := r.NextRetryDelay(t0)
 	d2 := r.NextRetryDelay(t0.Add(time.Second))
@@ -51,7 +51,7 @@ func TestJitterWithBackoff(t *testing.T) {
 	d0 := time.Second
 	max := time.Minute
 	seed := int64(1000)
-	r := newRetryDelayStrategy(d0, 0, newDefaultBackoff(max), newDefaultJitter(seed))
+	r := newRetryDelayStrategy(d0, 0, newDefaultBackoff(max), newDefaultJitter(0.5, seed))
 	t0 := time.Now().Add(-time.Minute)
 	d1 := r.NextRetryDelay(t0)
 	d2 := r.NextRetryDelay(t0.Add(time.Second))

--- a/stream.go
+++ b/stream.go
@@ -93,7 +93,6 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 	configuredOptions := streamOptions{
 		httpClient:         &defaultClient,
 		initialRetry:       DefaultInitialRetry,
-		maxRetry:           DefaultMaxRetry,
 		retryResetInterval: DefaultRetryResetInterval,
 	}
 
@@ -105,11 +104,11 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 
 	var backoff backoffStrategy
 	var jitter jitterStrategy
-	if configuredOptions.useBackoff {
-		backoff = newDefaultBackoff(configuredOptions.maxRetry)
+	if configuredOptions.backoffMaxDelay > 0 {
+		backoff = newDefaultBackoff(configuredOptions.backoffMaxDelay)
 	}
-	if configuredOptions.useJitter {
-		jitter = newDefaultJitter(0)
+	if configuredOptions.jitterRatio > 0 {
+		jitter = newDefaultJitter(configuredOptions.jitterRatio, 0)
 	}
 
 	stream := &Stream{

--- a/stream.go
+++ b/stream.go
@@ -17,8 +17,8 @@ type Stream struct {
 	c           *http.Client
 	req         *http.Request
 	lastEventID string
-	retry       time.Duration
 	readTimeout time.Duration
+	retryDelay  *retryDelayStrategy
 	// Events emits the events received by the stream
 	Events chan Event
 	// Errors emits any errors encountered while reading events from the stream.
@@ -33,99 +33,6 @@ type Stream struct {
 	mu          sync.RWMutex
 	connections int
 }
-
-// StreamOption is a common interface for optional configuration parameters that can be
-// used in creating a stream.
-type StreamOption interface {
-	apply(s *Stream) error
-}
-
-type readTimeoutOption struct {
-	timeout time.Duration
-}
-
-func (o readTimeoutOption) apply(s *Stream) error {
-	s.readTimeout = o.timeout
-	return nil
-}
-
-// StreamOptionReadTimeout returns an option that sets the read timeout interval for a
-// stream when the stream is created. If the stream does not receive new data within this
-// length of time, it will restart the connection. By default, there is no read timeout.
-func StreamOptionReadTimeout(timeout time.Duration) StreamOption {
-	return readTimeoutOption{timeout: timeout}
-}
-
-type initialRetryOption struct {
-	retry time.Duration
-}
-
-func (o initialRetryOption) apply(s *Stream) error {
-	s.retry = o.retry
-	return nil
-}
-
-// StreamOptionInitialRetry returns an option that sets the initial retry delay for a
-// stream when the stream is created. This will be used the first time the stream has to
-// be restarted; the interval will increase on subsequent reconnections. The default retry
-// delay is DefaultInitialRetry.
-func StreamOptionInitialRetry(retry time.Duration) StreamOption {
-	return initialRetryOption{retry: retry}
-}
-
-type lastEventIDOption struct {
-	lastEventID string
-}
-
-func (o lastEventIDOption) apply(s *Stream) error {
-	s.lastEventID = o.lastEventID
-	return nil
-}
-
-// StreamOptionLastEventID returns an option that sets the initial last event ID for a
-// stream when the stream is created. If specified, this value will be sent to the server
-// in case it can replay missed events.
-func StreamOptionLastEventID(lastEventID string) StreamOption {
-	return lastEventIDOption{lastEventID: lastEventID}
-}
-
-type httpClientOption struct {
-	client *http.Client
-}
-
-func (o httpClientOption) apply(s *Stream) error {
-	if o.client != nil {
-		s.c = o.client
-	}
-	return nil
-}
-
-// StreamOptionHTTPClient returns an option that overrides the default HTTP client used by
-// a stream when the stream is created.
-func StreamOptionHTTPClient(client *http.Client) StreamOption {
-	return httpClientOption{client: client}
-}
-
-type loggerOption struct {
-	logger Logger
-}
-
-func (o loggerOption) apply(s *Stream) error {
-	s.Logger = o.logger
-	return nil
-}
-
-// StreamOptionLogger returns an option that sets the logger for a stream when the stream
-// is created (to change it later, you can use SetLogger). By default, there is no logger.
-func StreamOptionLogger(logger Logger) StreamOption {
-	return loggerOption{logger: logger}
-}
-
-const (
-	// DefaultInitialRetry is the initial reconnection delay that will be used if no other
-	// value is specified.
-	DefaultInitialRetry = time.Second * 3
-)
 
 var (
 	// ErrReadTimeout is the error that will be emitted if a stream was closed due to not
@@ -183,31 +90,74 @@ func SubscribeWith(lastEventID string, client *http.Client, request *http.Reques
 func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOption) (*Stream, error) {
 	defaultClient := *http.DefaultClient
 
-	stream := &Stream{
-		c:      &defaultClient,
-		req:    request,
-		retry:  DefaultInitialRetry,
-		Events: make(chan Event),
-		Errors: make(chan error),
-		closer: make(chan struct{}),
+	configuredOptions := streamOptions{
+		httpClient:         &defaultClient,
+		initialRetry:       DefaultInitialRetry,
+		maxRetry:           DefaultMaxRetry,
+		retryResetInterval: DefaultRetryResetInterval,
 	}
 
 	for _, o := range options {
-		if err := o.apply(stream); err != nil {
+		if err := o.apply(&configuredOptions); err != nil {
 			return nil, err
 		}
+	}
+
+	var backoff backoffStrategy
+	var jitter jitterStrategy
+	if configuredOptions.useBackoff {
+		backoff = newDefaultBackoff(configuredOptions.maxRetry)
+	}
+	if configuredOptions.useJitter {
+		jitter = newDefaultJitter(0)
+	}
+
+	stream := &Stream{
+		c:           configuredOptions.httpClient,
+		lastEventID: configuredOptions.lastEventID,
+		readTimeout: configuredOptions.readTimeout,
+		req:         request,
+		retryDelay:  newRetryDelayStrategy(configuredOptions.initialRetry, configuredOptions.retryResetInterval, backoff, jitter),
+		Events:      make(chan Event),
+		Errors:      make(chan error),
+		Logger:      configuredOptions.logger,
+		closer:      make(chan struct{}),
 	}
 
 	// override checkRedirect to include headers before go1.8
 	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
 	setCheckRedirect(stream.c)
 
-	r, err := stream.connect()
-	if err != nil {
-		return nil, err
+	var initialRetryTimeoutCh <-chan time.Time
+	var lastError error
+	if configuredOptions.initialRetryTimeout > 0 {
+		initialRetryTimeoutCh = time.After(configuredOptions.initialRetryTimeout)
 	}
-	go stream.stream(r)
-	return stream, nil
+	for {
+		r, err := stream.connect()
+		if err == nil {
+			go stream.stream(r)
+			return stream, nil
+		}
+		lastError = err
+		if configuredOptions.initialRetryTimeout == 0 {
+			return nil, err
+		}
+		delay := stream.retryDelay.NextRetryDelay(time.Now())
+		if configuredOptions.logger != nil {
+			configuredOptions.logger.Printf("Connection failed (%s), retrying in %0.4f secs\n", err, delay.Seconds())
+		}
+		nextRetryCh := time.After(delay)
+		select {
+		case <-initialRetryTimeoutCh:
+			if lastError == nil {
+				lastError = errors.New("timeout elapsed while waiting to connect")
+			}
+			return nil, lastError
+		case <-nextRetryCh:
+			break
+		}
+	}
 }
 
 // Close will close the stream. It is safe for concurrent access and can be called multiple times.
@@ -255,20 +205,19 @@ func (stream *Stream) connect() (io.ReadCloser, error) {
 func (stream *Stream) stream(r io.ReadCloser) {
 	retryChan := make(chan struct{}, 1)
 
-	scheduleRetry := func(backoff *time.Duration) {
+	scheduleRetry := func() {
 		logger := stream.getLogger()
+		delay := stream.retryDelay.NextRetryDelay(time.Now())
 		if logger != nil {
-			logger.Printf("Reconnecting in %0.4f secs\n", backoff.Seconds())
+			logger.Printf("Reconnecting in %0.4f secs\n", delay.Seconds())
 		}
-		time.AfterFunc(*backoff, func() {
+		time.AfterFunc(delay, func() {
 			retryChan <- struct{}{}
 		})
-		*backoff *= 2
 	}
 
 NewStream:
 	for {
-		backoff := stream.getRetry()
 		events := make(chan Event)
 		errs := make(chan error)
 
@@ -296,12 +245,12 @@ NewStream:
 				//nolint: gosec
 				_ = r.Close()
 				r = nil
-				scheduleRetry(&backoff)
+				scheduleRetry()
 				continue NewStream
 			case ev := <-events:
 				pub := ev.(*publication)
 				if pub.Retry() > 0 {
-					backoff = time.Duration(pub.Retry()) * time.Millisecond
+					stream.retryDelay.SetBaseDelay(time.Duration(pub.Retry()) * time.Millisecond)
 				}
 				if len(pub.Id()) > 0 {
 					stream.lastEventID = pub.Id()
@@ -324,7 +273,7 @@ NewStream:
 				if err != nil {
 					r = nil
 					stream.Errors <- err
-					scheduleRetry(&backoff)
+					scheduleRetry()
 				}
 				continue NewStream
 			}
@@ -335,16 +284,8 @@ NewStream:
 	close(stream.Events)
 }
 
-func (stream *Stream) setRetry(retry time.Duration) { // nolint:megacheck // unused except by tests
-	stream.mu.Lock()
-	defer stream.mu.Unlock()
-	stream.retry = retry
-}
-
-func (stream *Stream) getRetry() time.Duration {
-	stream.mu.RLock()
-	defer stream.mu.RUnlock()
-	return stream.retry
+func (stream *Stream) getRetryDelayStrategy() *retryDelayStrategy { // nolint:megacheck // unused except by tests
+	return stream.retryDelay
 }
 
 // SetLogger sets the Logger field in a thread-safe manner.

--- a/stream.go
+++ b/stream.go
@@ -260,6 +260,7 @@ NewStream:
 				if len(pub.Id()) > 0 {
 					stream.lastEventID = pub.Id()
 				}
+				stream.retryDelay.SetGoodSince(time.Now())
 				stream.Events <- ev
 			case <-stream.closer:
 				if r != nil {

--- a/stream_options.go
+++ b/stream_options.go
@@ -6,16 +6,15 @@ import (
 )
 
 type streamOptions struct {
-	initialRetry            time.Duration
-	httpClient              *http.Client
-	lastEventID             string
-	logger                  Logger
-	backoffMaxDelay         time.Duration
-	jitterRatio             float64
-	canRetryFirstConnection bool
-	readTimeout             time.Duration
-	retryResetInterval      time.Duration
-	initialRetryTimeout     time.Duration
+	initialRetry        time.Duration
+	httpClient          *http.Client
+	lastEventID         string
+	logger              Logger
+	backoffMaxDelay     time.Duration
+	jitterRatio         float64
+	readTimeout         time.Duration
+	retryResetInterval  time.Duration
+	initialRetryTimeout time.Duration
 }
 
 // StreamOption is a common interface for optional configuration parameters that can be

--- a/stream_options.go
+++ b/stream_options.go
@@ -1,0 +1,239 @@
+package eventsource
+
+import (
+	"net/http"
+	"time"
+)
+
+type streamOptions struct {
+	initialRetry            time.Duration
+	httpClient              *http.Client
+	lastEventID             string
+	logger                  Logger
+	useBackoff              bool
+	useJitter               bool
+	canRetryFirstConnection bool
+	maxRetry                time.Duration
+	readTimeout             time.Duration
+	retryResetInterval      time.Duration
+	initialRetryTimeout     time.Duration
+}
+
+// StreamOption is a common interface for optional configuration parameters that can be
+// used in creating a stream.
+type StreamOption interface {
+	apply(s *streamOptions) error
+}
+
+type readTimeoutOption struct {
+	timeout time.Duration
+}
+
+func (o readTimeoutOption) apply(s *streamOptions) error {
+	s.readTimeout = o.timeout
+	return nil
+}
+
+// StreamOptionReadTimeout returns an option that sets the read timeout interval for a
+// stream when the stream is created. If the stream does not receive new data within this
+// length of time, it will restart the connection.
+//
+// By default, there is no read timeout.
+func StreamOptionReadTimeout(timeout time.Duration) StreamOption {
+	return readTimeoutOption{timeout: timeout}
+}
+
+type initialRetryOption struct {
+	retry time.Duration
+}
+
+func (o initialRetryOption) apply(s *streamOptions) error {
+	s.initialRetry = o.retry
+	return nil
+}
+
+// StreamOptionInitialRetry returns an option that sets the initial retry delay for a
+// stream when the stream is created.
+//
+// This delay will be used the first time the stream has to be restarted; the interval will
+// increase exponentially on subsequent reconnections. Each time, there will also be a
+// pseudo-random jitter so that the actual value may be up to 50% less. So, for instance,
+// if you set the initial delay to 1 second, the first reconnection will use a delay between
+// 0.5s and 1s inclusive, and subsequent reconnections will be 1s-2s, 2s-4s, etc.
+//
+// The default value is DefaultInitialRetry. In a future version, this value may change, so
+// if you need a specific value it is best to set it explicitly.
+func StreamOptionInitialRetry(retry time.Duration) StreamOption {
+	return initialRetryOption{retry: retry}
+}
+
+type maxRetryOption struct {
+	maxRetry time.Duration
+}
+
+func (o maxRetryOption) apply(s *streamOptions) error {
+	s.maxRetry = o.maxRetry
+	return nil
+}
+
+type useBackoffOption struct {
+	value bool
+}
+
+func (o useBackoffOption) apply(s *streamOptions) error {
+	s.useBackoff = o.value
+	return nil
+}
+
+// StreamOptionUseBackoff returns an option that determines whether to use an exponential
+// backoff for reconnection delays.
+//
+// If enabled, the retry delay interval will be doubled (not counting jitter - see
+// StreamOptionUseJitter) for consecutive stream reconnections, subject to the limit
+// specified by StreamOptionMaxRetry.
+//
+// For consistency with earlier versions, this is currently disabled (false) by default. In
+// a future version it will default to enabled (true), so if you do not want backoff
+// behavior you should explicitly set it to false. It is recommended to use both backoff
+// and jitter, to avoid "thundering herd" behavior in the case of a server outage.
+func StreamOptionUseBackoff(useBackoff bool) StreamOption {
+	return useBackoffOption{useBackoff}
+}
+
+type canRetryFirstConnectionOption struct {
+	initialRetryTimeout time.Duration
+}
+
+func (o canRetryFirstConnectionOption) apply(s *streamOptions) error {
+	s.initialRetryTimeout = o.initialRetryTimeout
+	return nil
+}
+
+// StreamOptionCanRetryFirstConnection returns an option that determines whether to apply
+// retry behavior to the first connection attempt for the stream.
+//
+// If the timeout is nonzero, an initial connection failure when subscribing will not cause an
+// error result, but will trigger the same retry logic as if an existing connection had failed.
+// The stream constructor will not return until a connection has been made, or until the
+// specified timeout expires, if the timeout is positive; if the timeout is negative, it
+// will continue retrying indefinitely.
+//
+// The default value is zero: an initial connection failure will not be retried.
+func StreamOptionCanRetryFirstConnection(initialRetryTimeout time.Duration) StreamOption {
+	return canRetryFirstConnectionOption{initialRetryTimeout}
+}
+
+type useJitterOption struct {
+	value bool
+}
+
+func (o useJitterOption) apply(s *streamOptions) error {
+	s.useJitter = o.value
+	return nil
+}
+
+// StreamOptionUseJitter returns an option that determines whether to use a randomized
+// jitter for reconnection delays.
+//
+// If enabled, then whatever retry delay interval would otherwise be used is randomly
+// decreased by up to 50%.
+//
+// For consistency with earlier versions, this is currently disabled (false) by default. In
+// a future version it will default to enabled (true), so if you do not want jitter you
+// should explicitly set it to false. It is recommended to use both backoff and jitter, to
+// avoid "thundering herd" behavior in the case of a server outage.
+func StreamOptionUseJitter(useJitter bool) StreamOption {
+	return useJitterOption{useJitter}
+}
+
+// StreamOptionMaxRetry returns an option that sets the maximum retry delay for a
+// stream when the stream is created. This is only relevant if backoff is enabled (see
+// StreamOptionUseBackoff).
+//
+// If the stream has to be restarted multiple times, the retry delay interval will increase
+// using an exponential backoff interval but will never be longer than this maximum.
+//
+// The default value is DefaultMaxRetry.
+func StreamOptionMaxRetry(maxRetry time.Duration) StreamOption {
+	return maxRetryOption{maxRetry: maxRetry}
+}
+
+type retryResetIntervalOption struct {
+	retryResetInterval time.Duration
+}
+
+func (o retryResetIntervalOption) apply(s *streamOptions) error {
+	s.retryResetInterval = o.retryResetInterval
+	return nil
+}
+
+// StreamOptionRetryResetInterval returns an option that sets the minimum amount of time that a
+// connection must stay open before the Stream resets its backoff delay. This is only relevant if
+// backoff is enabled (see StreamOptionUseBackoff).
+//
+// If a connection fails before the threshold has elapsed, the delay before reconnecting will be
+// greater than the last delay; if it fails after the threshold, the delay will start over at the
+// the initial minimum value. This prevents long delays from occurring on connections that are only
+// rarely restarted.
+//
+// The default value is DefaultRetryResetInterval.
+func StreamOptionRetryResetInterval(retryResetInterval time.Duration) StreamOption {
+	return retryResetIntervalOption{retryResetInterval: retryResetInterval}
+}
+
+type lastEventIDOption struct {
+	lastEventID string
+}
+
+func (o lastEventIDOption) apply(s *streamOptions) error {
+	s.lastEventID = o.lastEventID
+	return nil
+}
+
+// StreamOptionLastEventID returns an option that sets the initial last event ID for a
+// stream when the stream is created. If specified, this value will be sent to the server
+// in case it can replay missed events.
+func StreamOptionLastEventID(lastEventID string) StreamOption {
+	return lastEventIDOption{lastEventID: lastEventID}
+}
+
+type httpClientOption struct {
+	client *http.Client
+}
+
+func (o httpClientOption) apply(s *streamOptions) error {
+	if o.client != nil {
+		s.httpClient = o.client
+	}
+	return nil
+}
+
+// StreamOptionHTTPClient returns an option that overrides the default HTTP client used by
+// a stream when the stream is created.
+func StreamOptionHTTPClient(client *http.Client) StreamOption {
+	return httpClientOption{client: client}
+}
+
+type loggerOption struct {
+	logger Logger
+}
+
+func (o loggerOption) apply(s *streamOptions) error {
+	s.logger = o.logger
+	return nil
+}
+
+// StreamOptionLogger returns an option that sets the logger for a stream when the stream
+// is created (to change it later, you can use SetLogger). By default, there is no logger.
+func StreamOptionLogger(logger Logger) StreamOption {
+	return loggerOption{logger: logger}
+}
+
+const (
+	// DefaultInitialRetry is the default value for StreamOptionalInitialRetry.
+	DefaultInitialRetry = time.Second * 3
+	// DefaultMaxRetry is the default value for StreamOptionMaxRetry.
+	DefaultMaxRetry = time.Second * 30
+	// DefaultRetryResetInterval is the default value for StreamOptionRetryResetInterval.
+	DefaultRetryResetInterval = time.Second * 60
+)

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,8 +2,9 @@ package eventsource
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,9 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/launchdarkly/go-test-helpers/httphelpers"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -19,17 +23,16 @@ const (
 )
 
 func TestStreamSubscribeEventsChan(t *testing.T) {
-	server := NewServer()
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
-	// The server has to be closed before the httpServer is closed.
-	// Otherwise the httpServer has still an open connection and it can not close.
+	streamHandler, events, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
 	defer httpServer.Close()
-	defer server.Close()
+	defer close(closer)
 
 	stream := mustSubscribe(t, httpServer.URL)
+	defer stream.Close()
 
 	publishedEvent := &publication{id: "123"}
-	server.Publish([]string{eventChannelName}, publishedEvent)
+	events <- publishedEvent
 
 	select {
 	case receivedEvent := <-stream.Events:
@@ -42,31 +45,28 @@ func TestStreamSubscribeEventsChan(t *testing.T) {
 }
 
 func TestStreamSubscribeErrorsChan(t *testing.T) {
-	server := NewServer()
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
-
+	streamHandler, _, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
 	defer httpServer.Close()
+	defer close(closer)
 
 	stream := mustSubscribe(t, httpServer.URL)
-	server.Close()
+	defer stream.Close()
+	closer <- struct{}{}
 
 	select {
 	case err := <-stream.Errors:
-		if err != io.EOF {
-			t.Errorf("got error %+v, want %+v", err, io.EOF)
-		}
+		assert.Equal(t, io.EOF, err)
 	case <-time.After(timeToWaitForEvent):
 		t.Error("Timed out waiting for error event")
 	}
 }
 
 func TestStreamClose(t *testing.T) {
-	server := NewServer()
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
-	// The server has to be closed before the httpServer is closed.
-	// Otherwise the httpServer has still an open connection and it can not close.
+	streamHandler, _, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
 	defer httpServer.Close()
-	defer server.Close()
+	defer close(closer)
 
 	stream := mustSubscribe(t, httpServer.URL)
 	stream.Close()
@@ -93,17 +93,16 @@ func TestStreamClose(t *testing.T) {
 }
 
 func TestStreamReconnect(t *testing.T) {
-	server := NewServer()
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
-	// The server has to be closed before the httpServer is closed.
-	// Otherwise the httpServer has still an open connection and it can not close.
+	streamHandler, events, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
 	defer httpServer.Close()
-	defer server.Close()
+	defer close(closer)
 
-	stream := mustSubscribe(t, httpServer.URL)
-	stream.setRetry(time.Millisecond)
+	stream := mustSubscribe(t, httpServer.URL, StreamOptionInitialRetry(time.Millisecond))
+	defer stream.Close()
+
 	publishedEvent := &publication{id: "123"}
-	server.Publish([]string{eventChannelName}, publishedEvent)
+	events <- publishedEvent
 
 	select {
 	case <-stream.Events:
@@ -112,7 +111,7 @@ func TestStreamReconnect(t *testing.T) {
 		return
 	}
 
-	httpServer.CloseClientConnections()
+	closer <- struct{}{}
 
 	// Expect at least one error
 	select {
@@ -122,11 +121,7 @@ func TestStreamReconnect(t *testing.T) {
 		return
 	}
 
-	go func() {
-		// Publish again after we've reconnected
-		time.Sleep(time.Second)
-		server.Publish([]string{eventChannelName}, publishedEvent)
-	}()
+	events <- publishedEvent
 
 	// Consume errors until we've got another event
 	for {
@@ -144,72 +139,68 @@ func TestStreamReconnect(t *testing.T) {
 	}
 }
 
-func TestStreamReconnectWithReportSendsBodyTwice(t *testing.T) {
-	connections := make(chan struct{}, 2)
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := ioutil.ReadAll(r.Body)
-		if string(body) != "my-body" {
-			t.Error("didn't get expected body")
-		}
-		connections <- struct{}{}
-		ticker := time.NewTicker(time.Millisecond)
-		defer ticker.Stop()
-		for range ticker.C {
-			// Just send comments
-			if _, err := w.Write([]byte(":\n")); err != nil {
-				return
-			}
-		}
-	}))
+func TestStreamSendsLastEventID(t *testing.T) {
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(streamHandler)
 
+	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
+	defer close(closer)
 
-	req, _ := http.NewRequest("REPORT", httpServer.URL, bytes.NewBufferString("my-body"))
+	lastID := "xyz"
+	stream := mustSubscribe(t, httpServer.URL, StreamOptionLastEventID(lastID))
+	defer stream.Close()
+
+	r0 := <-requestsCh
+	assert.Equal(t, lastID, r0.Request.Header.Get("Last-Event-ID"))
+}
+
+func TestStreamReconnectWithReportSendsBodyTwice(t *testing.T) {
+	body := []byte("my-body")
+
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(streamHandler)
+
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	req, _ := http.NewRequest("REPORT", httpServer.URL, bytes.NewBuffer(body))
 	if req.GetBody == nil {
 		t.Fatalf("Expected get body to be set")
 	}
-	stream, err := SubscribeWithRequest("", req)
+	stream, err := SubscribeWithRequestAndOptions(req, StreamOptionInitialRetry(time.Millisecond))
 	if err != nil {
 		t.Fatalf("Failed to subscribe: %s", err)
 		return
 	}
+	defer stream.Close()
 
-	// Acknowledge initial connection
-	<-connections
+	// Wait for the first request
+	r0 := <-requestsCh
 
-	stream.setRetry(time.Millisecond)
+	// Allow the stream to reconnect once; get the second request
+	closer <- struct{}{}
+	<-stream.Errors // Accept the error to unblock the retry handler
+	r1 := <-requestsCh
 
-	// Kick everyone off
-	httpServer.CloseClientConnections()
-
-	// Accept the error to unblock the retry handler
-	<-stream.Errors
-
-	// Wait for a second connection attempt
-WaitForSecondConnection:
-	for {
-		select {
-		case <-connections:
-			break WaitForSecondConnection
-		case <-time.After(2 * time.Second):
-			t.Fatalf("Timed out waiting for second connection")
-			return
-		}
-	}
 	stream.Close()
 
-	// Speed up the close by eliminating current connections
-	httpServer.CloseClientConnections()
+	assert.Equal(t, body, r0.Body)
+	assert.Equal(t, body, r1.Body)
 }
 
 func TestStreamCloseWhileReconnecting(t *testing.T) {
-	server := NewServer()
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+	streamHandler, events, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
+	defer httpServer.Close()
+	defer close(closer)
 
-	stream := mustSubscribe(t, httpServer.URL)
-	stream.setRetry(time.Hour)
+	stream := mustSubscribe(t, httpServer.URL, StreamOptionInitialRetry(time.Hour))
+	defer stream.Close()
+
 	publishedEvent := &publication{id: "123"}
-	server.Publish([]string{eventChannelName}, publishedEvent)
+	events <- publishedEvent
 
 	select {
 	case <-stream.Events:
@@ -218,8 +209,7 @@ func TestStreamCloseWhileReconnecting(t *testing.T) {
 		return
 	}
 
-	server.Close()
-	httpServer.Close()
+	closer <- struct{}{}
 
 	// Expect at least one error
 	select {
@@ -253,19 +243,20 @@ func TestStreamCloseWhileReconnecting(t *testing.T) {
 func TestStreamReadTimeout(t *testing.T) {
 	timeout := time.Millisecond * 200
 
-	server := NewServer()
-	server.ReplayAll = true
-	publishedEvent := &publication{data: "123"}
-	repo := NewSliceRepository()
-	repo.Add(eventChannelName, publishedEvent)
-	server.Register(eventChannelName, repo)
-	// this makes it send exactly one event for each connection
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+	streamHandler1, events1, closer1 := closeableStreamHandler()
+	streamHandler2, events2, closer2 := closeableStreamHandler()
+	httpServer := httptest.NewServer(httphelpers.SequentialHandler(streamHandler1, streamHandler2))
 	defer httpServer.Close()
-	defer server.Close()
+	defer close(closer1)
+	defer close(closer2)
 
 	stream := mustSubscribe(t, httpServer.URL, StreamOptionReadTimeout(timeout),
 		StreamOptionInitialRetry(time.Millisecond))
+	defer stream.Close()
+
+	publishedEvent := &publication{id: "123"}
+	events1 <- publishedEvent
+	events2 <- publishedEvent
 
 	var receivedEvents []Event
 	var receivedErrors []error
@@ -300,31 +291,32 @@ ReadLoop:
 func TestStreamReadTimeoutIsPreventedByComment(t *testing.T) {
 	timeout := time.Millisecond * 200
 
-	server := NewServer()
-	server.ReplayAll = true
-	publishedEvent := &publication{data: "123"}
-	repo := NewSliceRepository()
-	repo.Add(eventChannelName, publishedEvent)
-	server.Register(eventChannelName, repo)
-	// this makes it send exactly one event for each connection
-	httpServer := httptest.NewServer(server.Handler(eventChannelName))
+	streamHandler1, events1, closer1 := closeableStreamHandler()
+	streamHandler2, _, closer2 := closeableStreamHandler()
+	httpServer := httptest.NewServer(httphelpers.SequentialHandler(streamHandler1, streamHandler2))
 	defer httpServer.Close()
-	defer server.Close()
+	defer close(closer1)
+	defer close(closer2)
 
 	stream := mustSubscribe(t, httpServer.URL, StreamOptionReadTimeout(timeout),
 		StreamOptionInitialRetry(time.Millisecond))
+	defer stream.Close()
+
+	publishedEvent := &publication{id: "123"}
+	events1 <- publishedEvent
 
 	var receivedEvents []Event
 	var receivedErrors []error
 
 	waitUntil := time.After(timeout + (timeout / 2))
-	time.Sleep(time.Duration(float64(timeout) * 0.75))
-	server.PublishComment([]string{eventChannelName}, "")
+
 ReadLoop:
 	for {
 		select {
 		case e := <-stream.Events:
 			receivedEvents = append(receivedEvents, e)
+			time.Sleep(time.Duration(float64(timeout) * 0.75))
+			events1 <- nil // nil causes the handler to send a comment
 		case err := <-stream.Errors:
 			receivedErrors = append(receivedErrors, err)
 		case <-waitUntil:
@@ -342,11 +334,251 @@ ReadLoop:
 	}
 }
 
+func TestStreamCanUseBackoff(t *testing.T) {
+	streamHandler, _, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	baseDelay := time.Millisecond
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionInitialRetry(baseDelay),
+		StreamOptionUseBackoff(true))
+	defer stream.Close()
+
+	retry := stream.getRetryDelayStrategy()
+	assert.False(t, retry.hasJitter())
+	d0 := retry.NextRetryDelay(time.Now())
+	d1 := retry.NextRetryDelay(time.Now())
+	d2 := retry.NextRetryDelay(time.Now())
+	assert.Equal(t, baseDelay, d0)
+	assert.Equal(t, baseDelay*2, d1)
+	assert.Equal(t, baseDelay*4, d2)
+}
+
+func TestStreamCanUseJitter(t *testing.T) {
+	streamHandler, _, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	baseDelay := time.Millisecond
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionInitialRetry(baseDelay),
+		StreamOptionUseBackoff(true),
+		StreamOptionUseJitter(true))
+	defer stream.Close()
+
+	retry := stream.getRetryDelayStrategy()
+	assert.True(t, retry.hasJitter())
+	d0 := retry.NextRetryDelay(time.Now())
+	d1 := retry.NextRetryDelay(time.Now())
+	assert.True(t, d0 >= baseDelay/2)
+	assert.True(t, d0 <= baseDelay)
+	assert.True(t, d1 >= baseDelay)
+	assert.True(t, d1 <= baseDelay*2)
+}
+
+func TestStreamCanSetMaximumDelayWithBackoff(t *testing.T) {
+	streamHandler, _, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	baseDelay := time.Millisecond
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionInitialRetry(baseDelay),
+		StreamOptionUseBackoff(true),
+		StreamOptionMaxRetry(baseDelay*3))
+	defer stream.Close()
+
+	retry := stream.getRetryDelayStrategy()
+	assert.False(t, retry.hasJitter())
+	d0 := retry.NextRetryDelay(time.Now())
+	d1 := retry.NextRetryDelay(time.Now())
+	d2 := retry.NextRetryDelay(time.Now())
+	assert.Equal(t, baseDelay, d0)
+	assert.Equal(t, baseDelay*2, d1)
+	assert.Equal(t, baseDelay*3, d2)
+}
+
+func TestStreamCanChangeRetryDelayBasedOnEvent(t *testing.T) {
+	streamHandler, events, closer := closeableStreamHandler()
+	httpServer := httptest.NewServer(streamHandler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	baseDelay := time.Millisecond
+	stream := mustSubscribe(t, httpServer.URL, StreamOptionInitialRetry(baseDelay))
+	defer stream.Close()
+
+	newRetryMillis := int64(3000)
+	event := &publication{event: "event1", data: "a", retry: newRetryMillis}
+	events <- event
+
+	<-stream.Events
+
+	retry := stream.getRetryDelayStrategy()
+	d := retry.NextRetryDelay(time.Now())
+	assert.Equal(t, time.Millisecond*time.Duration(newRetryMillis), d)
+}
+
+func TestStreamCanUseCustomClient(t *testing.T) {
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(streamHandler)
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	client := *http.DefaultClient
+	client.Transport = urlSuffixingRoundTripper{http.DefaultTransport, "path"}
+
+	stream := mustSubscribe(t, httpServer.URL, StreamOptionHTTPClient(&client))
+	defer stream.Close()
+
+	r := <-requestsCh
+	assert.Equal(t, "/path", r.Request.URL.Path)
+}
+
+func TestStreamDoesNotRetryInitialConnectionByDefault(t *testing.T) {
+	connectionFailureHandler := httphelpers.PanicHandler(errors.New("sorry"))
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(connectionFailureHandler, streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	stream, err := SubscribeWithURL(httpServer.URL)
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.Error(t, err)
+
+	assert.Equal(t, 1, len(requestsCh))
+}
+
+func TestStreamCanRetryInitialConnection(t *testing.T) {
+	connectionFailureHandler := httphelpers.PanicHandler(errors.New("sorry"))
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(
+		connectionFailureHandler,
+		connectionFailureHandler,
+		streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	stream, err := SubscribeWithURL(httpServer.URL,
+		StreamOptionInitialRetry(time.Millisecond),
+		StreamOptionCanRetryFirstConnection(time.Second*2))
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(requestsCh))
+}
+
+func TestStreamCanRetryInitialConnectionWithIndefiniteTimeout(t *testing.T) {
+	connectionFailureHandler := httphelpers.PanicHandler(errors.New("sorry"))
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(
+		connectionFailureHandler,
+		connectionFailureHandler,
+		streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	stream, err := SubscribeWithURL(httpServer.URL,
+		StreamOptionInitialRetry(time.Millisecond),
+		StreamOptionCanRetryFirstConnection(-1))
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(requestsCh))
+}
+
+func TestStreamCanRetryInitialConnectionUntilFiniteTimeout(t *testing.T) {
+	connectionFailureHandler := httphelpers.PanicHandler(errors.New("sorry"))
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(
+		connectionFailureHandler,
+		connectionFailureHandler,
+		streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	stream, err := SubscribeWithURL(httpServer.URL,
+		StreamOptionInitialRetry(100*time.Millisecond),
+		StreamOptionCanRetryFirstConnection(150*time.Millisecond))
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.Error(t, err)
+
+	assert.Equal(t, 2, len(requestsCh))
+}
+
 func mustSubscribe(t *testing.T, url string, options ...StreamOption) *Stream {
-	stream, err := SubscribeWithURL(url, options...)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	allOpts := append(options, StreamOptionLogger(logger))
+	stream, err := SubscribeWithURL(url, allOpts...)
 	if err != nil {
 		t.Fatalf("Failed to subscribe: %s", err)
 	}
-	stream.SetLogger(log.New(os.Stderr, "", log.LstdFlags))
 	return stream
+}
+
+func closeableStreamHandler() (http.Handler, chan<- Event, chan<- struct{}) {
+	eventsCh := make(chan Event, 10)
+	closerCh := make(chan struct{}, 10)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/event-stream")
+		w.Header().Add("Transfer-Encoding", "chunked")
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		enc := NewEncoder(w, false)
+		for {
+			select {
+			case e := <-eventsCh:
+				if e == nil {
+					enc.Encode(comment{""})
+				} else {
+					if p, ok := e.(*publication); ok {
+						if p.Retry() > 0 { // Encoder doesn't support the retry: attribute
+							w.Write([]byte(fmt.Sprintf("retry:%d\n", p.Retry())))
+						}
+					}
+					enc.Encode(e)
+				}
+				w.(http.Flusher).Flush()
+			case <-closerCh:
+				return
+			}
+		}
+	})
+	return handler, eventsCh, closerCh
+}
+
+type urlSuffixingRoundTripper struct {
+	transport http.RoundTripper
+	suffix    string
+}
+
+func (u urlSuffixingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	url1, _ := req.URL.Parse(u.suffix)
+	req.URL = url1
+	return u.transport.RoundTrip(req)
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -343,7 +343,7 @@ func TestStreamCanUseBackoff(t *testing.T) {
 	baseDelay := time.Millisecond
 	stream := mustSubscribe(t, httpServer.URL,
 		StreamOptionInitialRetry(baseDelay),
-		StreamOptionUseBackoff(true))
+		StreamOptionUseBackoff(time.Minute))
 	defer stream.Close()
 
 	retry := stream.getRetryDelayStrategy()
@@ -365,8 +365,8 @@ func TestStreamCanUseJitter(t *testing.T) {
 	baseDelay := time.Millisecond
 	stream := mustSubscribe(t, httpServer.URL,
 		StreamOptionInitialRetry(baseDelay),
-		StreamOptionUseBackoff(true),
-		StreamOptionUseJitter(true))
+		StreamOptionUseBackoff(time.Minute),
+		StreamOptionUseJitter(0.5))
 	defer stream.Close()
 
 	retry := stream.getRetryDelayStrategy()
@@ -386,10 +386,10 @@ func TestStreamCanSetMaximumDelayWithBackoff(t *testing.T) {
 	defer close(closer)
 
 	baseDelay := time.Millisecond
+	max := baseDelay * 3
 	stream := mustSubscribe(t, httpServer.URL,
 		StreamOptionInitialRetry(baseDelay),
-		StreamOptionUseBackoff(true),
-		StreamOptionMaxRetry(baseDelay*3))
+		StreamOptionUseBackoff(max))
 	defer stream.Close()
 
 	retry := stream.getRetryDelayStrategy()
@@ -399,7 +399,7 @@ func TestStreamCanSetMaximumDelayWithBackoff(t *testing.T) {
 	d2 := retry.NextRetryDelay(time.Now())
 	assert.Equal(t, baseDelay, d0)
 	assert.Equal(t, baseDelay*2, d1)
-	assert.Equal(t, baseDelay*3, d2)
+	assert.Equal(t, max, d2)
 }
 
 func TestStreamCanChangeRetryDelayBasedOnEvent(t *testing.T) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -402,6 +402,53 @@ func TestStreamCanSetMaximumDelayWithBackoff(t *testing.T) {
 	assert.Equal(t, max, d2)
 }
 
+func TestStreamBackoffCanUseResetInterval(t *testing.T) {
+	// In this test, streamHandler1 sends an event, then breaks the connection too soon for the delay to be
+	// reset. We ask the retryDelayStrategy to compute the next delay; it should be higher than the initial
+	// value. Then streamHandler2 sends an event, and we verify that the next delay that *would* come from the
+	// retryDelayStrategy if the reset interval elapsed would be the initial delay, not a higher value.
+	streamHandler1, events1, closer1 := closeableStreamHandler()
+	streamHandler2, events2, closer2 := closeableStreamHandler()
+	httpServer := httptest.NewServer(httphelpers.SequentialHandler(streamHandler1, streamHandler2))
+	defer httpServer.Close()
+	defer close(closer1)
+	defer close(closer2)
+
+	baseDelay := time.Millisecond
+	resetInterval := time.Millisecond * 200
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionInitialRetry(baseDelay),
+		StreamOptionUseBackoff(time.Hour),
+		StreamOptionRetryResetInterval(resetInterval))
+	defer stream.Close()
+
+	retry := stream.getRetryDelayStrategy()
+
+	// The first stream connection sends an event, so the stream state becomes "good".
+	publishedEvent := &publication{id: "123"}
+	events1 <- publishedEvent
+	<-stream.Events
+
+	// We ask the retryDelayStrategy to compute the next two delay values; they should show an increase.
+	d0 := retry.NextRetryDelay(time.Now())
+	d1 := retry.NextRetryDelay(time.Now())
+	assert.Equal(t, baseDelay, d0)
+	assert.Equal(t, baseDelay*2, d1)
+
+	// The first connection is broken; the state becomes "bad".
+	closer1 <- struct{}{}
+	<-stream.Errors
+
+	// After it reconnects, the second connection receives an event and the state becomes "good" again.
+	events2 <- publishedEvent
+	<-stream.Events
+
+	// Now, ask the retryDelayStrategy what the next delay value would be if the next attempt happened
+	// 200 milliseconds from now (assuming the stream remained good). It should go back to baseDelay.
+	d2 := retry.NextRetryDelay(time.Now().Add(resetInterval))
+	assert.Equal(t, baseDelay, d2)
+}
+
 func TestStreamCanChangeRetryDelayBasedOnEvent(t *testing.T) {
 	streamHandler, events, closer := closeableStreamHandler()
 	httpServer := httptest.NewServer(streamHandler)


### PR DESCRIPTION
This PR adds several new configurable behaviors which will be used by the LaunchDarkly Go SDK. All of these are opt-in, so any existing code outside of the Go SDK that does not set them will not be affected.

* `StreamOptionUseBackoff(maxDelay)`: turns on exponential backoff, with a maximum of maxDelay.
* `StreamOptionUseJitter(ratio)`: turns on jitter, where ratio is the maximum proportion to be subtracted from the delay, from 0.0 to 1.0.
* `StreamOptionRetryResetInterval(interval)`: when used with backoff, causes the delay to reset to the initial value if the stream has been active for at least that long.
* `StreamOptionCanRetryFirstConnection(timeout)`: causes the initial Subscribe call to block until a connection succeeds (previously, the initial connection would never be retried if it failed).

I also made a number of test improvements as noted in PR comments.