### PR TITLE
add ability to use an error handler instead of a channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
           make test | tee output.txt
 
-      - run: make init && make lint
+      - run: make lint
       
       - store_test_results:
           path: /tmp/circle-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,11 @@ jobs:
     steps:
       - checkout
       - run: go get -u $COMMON_GO_PACKAGES
-      - run: go get -t ./...
 
       - run: |
           mkdir -p $CIRCLE_TEST_REPORTS
           trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
-          go test -race -v ./... | tee output.txt
+          make test | tee output.txt
 
       - run: make init && make lint
       

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
-GOLANGCI_VERSION=v1.10.2
+GOLANGCI_LINT_VERSION=v1.10.2
 # earlier versions of golangci-lint don't work in go 1.9
+
+LINTER=./bin/golangci-lint
+LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)
 
 SHELL=/bin/bash
 
-test: lint
+test:
 	go get -t ./...
 	go test -race -v ./...
 
-lint:
-	./bin/golangci-lint run ./...
+$(LINTER_VERSION_FILE):
+	rm -f $(LINTER)
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_LINT_VERSION)
+	touch $(LINTER_VERSION_FILE)
 
-init:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_VERSION)
+lint: $(LINTER_VERSION_FILE)
+	$(LINTER) run ./...
 
-.PHONY: init lint test
+.PHONY: lint test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ GOLANGCI_VERSION=v1.10.2
 SHELL=/bin/bash
 
 test: lint
-	go test
+	go get -t ./...
+	go test -race -v ./...
 
 lint:
 	./bin/golangci-lint run ./...

--- a/interface.go
+++ b/interface.go
@@ -30,3 +30,38 @@ type Logger interface {
 	Println(...interface{})
 	Printf(string, ...interface{})
 }
+
+// StreamErrorHandlerResult is a constant type for use with StreamErrorHandler.
+type StreamErrorHandlerResult string
+
+const (
+	// StreamErrorProceed is returned by a StreamOptionErrorHandler if the Stream should handle the error
+	// normally.
+	//
+	// If the error represents the failure of an existing connection, Stream will retry the connection. If
+	// the error happened during initialization of the Stream, then whether Stream will retry or not is
+	// configurable; see StreamOptionCanRetryFirstConnection.
+	//
+	// Stream will not push the error onto the Errors channel; if you have specified a StreamErrorHandler,
+	// the Errors channel is never used.
+	StreamErrorProceed StreamErrorHandlerResult = "proceed"
+	// StreamErrorStop is returned by a StreamConnectionErrorFilter if the Stream should handle the error
+	// by immediately stopping and not retrying, as if Close had been called.
+	//
+	// If the error occurred during initialization of the Stream, rather than on an existing connection,
+	// this will also result in the Subscribe function immediately returning the error.
+	StreamErrorStop StreamErrorHandlerResult = "stop"
+)
+
+// StreamErrorHandler is a function type used with StreamOptionErrorHandler.
+//
+// This function will be called whenever Stream encounters either a network error or an HTTP error response
+// status. The returned value determines whether Stream should retry as usual, or immediately stop.
+//
+// The error may be any I/O error returned by Go's networking types, or it may be the eventsource type
+// SubscriptionError representing an HTTP error response status.
+//
+// For errors during initialization of the Stream, this function will be called on the same goroutine that
+// called the Subscribe method; for errors on an existing connection, it will be called on a worker
+// goroutine. It should return promptly and not block the goroutine.
+type StreamErrorHandler func(error) StreamErrorHandlerResult

--- a/interface.go
+++ b/interface.go
@@ -36,7 +36,7 @@ type StreamErrorHandlerResult struct {
 	// CloseNow can be set to true to tell the Stream to immediately stop and not retry, as if Close had
 	// been called.
 	//
-	// If StopNow is false, the Stream will proceed as usual after an error: if there is an existing
+	// If CloseNow is false, the Stream will proceed as usual after an error: if there is an existing
 	// connection it will retry the connection, and if the Stream is still being initialized then the
 	// retry behavior is configurable (see StreamOptionCanRetryFirstConnection).
 	CloseNow bool

--- a/interface.go
+++ b/interface.go
@@ -44,6 +44,9 @@ const (
 	//
 	// Stream will not push the error onto the Errors channel; if you have specified a StreamErrorHandler,
 	// the Errors channel is never used.
+	//
+	// This is the default behavior, so if the handler returns an unknown value it will be treated the
+	// same as StreamErrorProceed.
 	StreamErrorProceed StreamErrorHandlerResult = "proceed"
 	// StreamErrorStop is returned by a StreamConnectionErrorFilter if the Stream should handle the error
 	// by immediately stopping and not retrying, as if Close had been called.

--- a/stream.go
+++ b/stream.go
@@ -22,12 +22,21 @@ type Stream struct {
 	// Events emits the events received by the stream
 	Events chan Event
 	// Errors emits any errors encountered while reading events from the stream.
-	// It's mainly for informative purposes - the client isn't required to take any
-	// action when an error is encountered. The stream will always attempt to continue,
-	// even if that involves reconnecting to the server.
-	Errors chan error
-	// Logger is a logger that, when set, will be used for logging debug messages
-	Logger      Logger // Set with SetLogger if you want your code to be thread-safe
+	//
+	// Errors during initialization of the stream are not pushed to this channel, since until the
+	// Subscribe method has returned the caller would not be able to consume the channel. If you have
+	// configured the Stream to be able to retry on initialization errors, but you still want to know
+	// about those errors or control how they are handled, use StreamOptionErrorHandler.
+	//
+	// If an error handler has been specified with StreamOptionErrorHandler, the Errors channel is
+	// not used and will be nil.
+	Errors       chan error
+	errorHandler StreamErrorHandler
+	// Logger is a logger that, when set, will be used for logging informational messages.
+	//
+	// This field is exported for backward compatibility, but should not be set directly because
+	// it may be used by multiple goroutines. Use SetLogger instead.
+	Logger      Logger
 	closer      chan struct{}
 	closeOnce   sync.Once
 	mu          sync.RWMutex
@@ -47,7 +56,11 @@ type SubscriptionError struct {
 }
 
 func (e SubscriptionError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Code, e.Message)
+	s := fmt.Sprintf("error %d", e.Code)
+	if e.Message != "" {
+		s = s + ": " + e.Message
+	}
+	return s
 }
 
 // Subscribe to the Events emitted from the specified url.
@@ -102,36 +115,7 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 		}
 	}
 
-	var backoff backoffStrategy
-	var jitter jitterStrategy
-	if configuredOptions.backoffMaxDelay > 0 {
-		backoff = newDefaultBackoff(configuredOptions.backoffMaxDelay)
-	}
-	if configuredOptions.jitterRatio > 0 {
-		jitter = newDefaultJitter(configuredOptions.jitterRatio, 0)
-	}
-	retryDelay := newRetryDelayStrategy(
-		configuredOptions.initialRetry,
-		configuredOptions.retryResetInterval,
-		backoff,
-		jitter,
-	)
-
-	stream := &Stream{
-		c:           configuredOptions.httpClient,
-		lastEventID: configuredOptions.lastEventID,
-		readTimeout: configuredOptions.readTimeout,
-		req:         request,
-		retryDelay:  retryDelay,
-		Events:      make(chan Event),
-		Errors:      make(chan error),
-		Logger:      configuredOptions.logger,
-		closer:      make(chan struct{}),
-	}
-
-	// override checkRedirect to include headers before go1.8
-	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
-	setCheckRedirect(stream.c)
+	stream := newStream(request, configuredOptions)
 
 	var initialRetryTimeoutCh <-chan time.Time
 	var lastError error
@@ -148,6 +132,14 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 		if configuredOptions.initialRetryTimeout == 0 {
 			return nil, err
 		}
+		if configuredOptions.errorHandler != nil {
+			action := configuredOptions.errorHandler(err)
+			if action == StreamErrorStop {
+				return nil, err
+			}
+		}
+		// We never push errors to the Errors channel during initialization-- the caller would have no way to
+		// consume the channel, since we haven't returned a Stream instance.
 		delay := stream.retryDelay.NextRetryDelay(time.Now())
 		if configuredOptions.logger != nil {
 			configuredOptions.logger.Printf("Connection failed (%s), retrying in %0.4f secs\n", err, delay.Seconds())
@@ -163,6 +155,46 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 			continue
 		}
 	}
+}
+
+func newStream(request *http.Request, configuredOptions streamOptions) *Stream {
+	var backoff backoffStrategy
+	var jitter jitterStrategy
+	if configuredOptions.backoffMaxDelay > 0 {
+		backoff = newDefaultBackoff(configuredOptions.backoffMaxDelay)
+	}
+	if configuredOptions.jitterRatio > 0 {
+		jitter = newDefaultJitter(configuredOptions.jitterRatio, 0)
+	}
+	retryDelay := newRetryDelayStrategy(
+		configuredOptions.initialRetry,
+		configuredOptions.retryResetInterval,
+		backoff,
+		jitter,
+	)
+
+	stream := &Stream{
+		c:            configuredOptions.httpClient,
+		lastEventID:  configuredOptions.lastEventID,
+		readTimeout:  configuredOptions.readTimeout,
+		req:          request,
+		retryDelay:   retryDelay,
+		Events:       make(chan Event),
+		errorHandler: configuredOptions.errorHandler,
+		Logger:       configuredOptions.logger,
+		closer:       make(chan struct{}),
+	}
+
+	if configuredOptions.errorHandler == nil {
+		// The Errors channel is only used if there is no error handler.
+		stream.Errors = make(chan error)
+	}
+
+	// override checkRedirect to include headers before go1.8
+	// we'd prefer to skip this because it is not thread-safe and breaks golang race condition checking
+	setCheckRedirect(stream.c)
+
+	return stream
 }
 
 // Close will close the stream. It is safe for concurrent access and can be called multiple times.
@@ -221,6 +253,19 @@ func (stream *Stream) stream(r io.ReadCloser) {
 		})
 	}
 
+	reportErrorAndMaybeContinue := func(err error) bool {
+		if stream.errorHandler != nil {
+			action := stream.errorHandler(err)
+			if action == StreamErrorStop {
+				stream.Close()
+				return false
+			}
+		} else if stream.Errors != nil {
+			stream.Errors <- err
+		}
+		return true
+	}
+
 NewStream:
 	for {
 		events := make(chan Event)
@@ -246,7 +291,9 @@ NewStream:
 		for {
 			select {
 			case err := <-errs:
-				stream.Errors <- err
+				if !reportErrorAndMaybeContinue(err) {
+					break NewStream
+				}
 				//nolint: gosec
 				_ = r.Close()
 				r = nil
@@ -278,7 +325,9 @@ NewStream:
 				r, err = stream.connect()
 				if err != nil {
 					r = nil
-					stream.Errors <- err
+					if !reportErrorAndMaybeContinue(err) {
+						break NewStream
+					}
 					scheduleRetry()
 				}
 				continue NewStream
@@ -286,7 +335,9 @@ NewStream:
 		}
 	}
 
-	close(stream.Errors)
+	if stream.Errors != nil {
+		close(stream.Errors)
+	}
 	close(stream.Events)
 }
 

--- a/stream.go
+++ b/stream.go
@@ -133,8 +133,8 @@ func SubscribeWithRequestAndOptions(request *http.Request, options ...StreamOpti
 			return nil, err
 		}
 		if configuredOptions.errorHandler != nil {
-			action := configuredOptions.errorHandler(err)
-			if action == StreamErrorStop {
+			result := configuredOptions.errorHandler(err)
+			if result.CloseNow {
 				return nil, err
 			}
 		}
@@ -255,8 +255,8 @@ func (stream *Stream) stream(r io.ReadCloser) {
 
 	reportErrorAndMaybeContinue := func(err error) bool {
 		if stream.errorHandler != nil {
-			action := stream.errorHandler(err)
-			if action == StreamErrorStop {
+			result := stream.errorHandler(err)
+			if result.CloseNow {
 				stream.Close()
 				return false
 			}

--- a/stream_test.go
+++ b/stream_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,11 +53,90 @@ func TestStreamSubscribeErrorsChan(t *testing.T) {
 
 	stream := mustSubscribe(t, httpServer.URL)
 	defer stream.Close()
+
 	closer <- struct{}{}
 
 	select {
 	case err := <-stream.Errors:
 		assert.Equal(t, io.EOF, err)
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for error event")
+	}
+}
+
+func TestStreamCanUseErrorHandlerInsteadOfChannelForErrorOnExistingConnection(t *testing.T) {
+	streamHandler1, _, closer1 := closeableStreamHandler()
+	streamHandler2, _, closer2 := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(streamHandler1, streamHandler2))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer1)
+	defer close(closer2)
+
+	myErrChannel := make(chan error)
+	defer close(myErrChannel)
+
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
+			myErrChannel <- err
+			return StreamErrorProceed
+		}),
+		StreamOptionInitialRetry(time.Millisecond))
+	defer stream.Close()
+	assert.Nil(t, stream.Errors)
+	<-requestsCh
+
+	closer1 <- struct{}{}
+
+	select {
+	case err := <-myErrChannel:
+		assert.Equal(t, io.EOF, err)
+		// wait for reconnection attempt
+		select {
+		case <-requestsCh:
+			return
+		case <-time.After(200 * time.Millisecond):
+			t.Error("Timed out waiting for reconnect")
+		}
+	case <-time.After(timeToWaitForEvent):
+		t.Error("Timed out waiting for error event")
+	}
+}
+
+func TestStreamErrorHandlerCanPreventRetryOnExistingConnection(t *testing.T) {
+	streamHandler1, _, closer1 := closeableStreamHandler()
+	streamHandler2, _, closer2 := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(streamHandler1, streamHandler2))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer1)
+	defer close(closer2)
+
+	myErrChannel := make(chan error)
+	defer close(myErrChannel)
+
+	stream := mustSubscribe(t, httpServer.URL,
+		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
+			myErrChannel <- err
+			return StreamErrorStop
+		}),
+		StreamOptionInitialRetry(time.Millisecond))
+	defer stream.Close()
+	assert.Nil(t, stream.Errors)
+	<-requestsCh
+
+	closer1 <- struct{}{}
+
+	select {
+	case err := <-myErrChannel:
+		assert.Equal(t, io.EOF, err)
+		// there should *not* be a reconnection attempt
+		select {
+		case <-requestsCh:
+			t.Error("Stream should not have reconnected, but did")
+		case <-time.After(200 * time.Millisecond):
+			return
+		}
 	case <-time.After(timeToWaitForEvent):
 		t.Error("Timed out waiting for error event")
 	}
@@ -576,6 +656,80 @@ func TestStreamCanRetryInitialConnectionUntilFiniteTimeout(t *testing.T) {
 	assert.Error(t, err)
 
 	assert.Equal(t, 2, len(requestsCh))
+}
+
+func TestStreamErrorHandlerCanAllowRetryOfInitialConnectionAfterNetworkError(t *testing.T) {
+	testStreamErrorHandlerCanAllowRetryOfInitialConnection(t, httphelpers.PanicHandler(errors.New("sorry")),
+		func(err error) {
+			if !strings.HasSuffix(err.Error(), "EOF") {
+				t.Errorf("expected EOF error, got %v", err)
+			}
+		})
+}
+
+func TestStreamErrorHandlerCanAllowRetryOfInitialConnectionAfterHTTPError(t *testing.T) {
+	testStreamErrorHandlerCanAllowRetryOfInitialConnection(t, httphelpers.HandlerWithStatus(401),
+		func(err error) {
+			assert.Equal(t, "error 401", err.Error())
+		})
+}
+
+func testStreamErrorHandlerCanAllowRetryOfInitialConnection(t *testing.T, errorHandler http.Handler, checkError func(error)) {
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(
+		errorHandler,
+		streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	myErrChannel := make(chan error, 1)
+
+	stream, err := SubscribeWithURL(httpServer.URL,
+		StreamOptionInitialRetry(100*time.Millisecond),
+		StreamOptionCanRetryFirstConnection(150*time.Millisecond),
+		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
+			myErrChannel <- err
+			return StreamErrorProceed
+		}))
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(myErrChannel))
+	e := <-myErrChannel
+	checkError(e)
+
+	assert.Equal(t, 2, len(requestsCh))
+}
+
+func TestStreamErrorHandlerCanPreventRetryOfInitialConnection(t *testing.T) {
+	connectionFailureHandler := httphelpers.PanicHandler(errors.New("sorry"))
+	streamHandler, _, closer := closeableStreamHandler()
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.SequentialHandler(
+		connectionFailureHandler,
+		streamHandler))
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+	defer close(closer)
+
+	stream, err := SubscribeWithURL(httpServer.URL,
+		StreamOptionInitialRetry(100*time.Millisecond),
+		StreamOptionCanRetryFirstConnection(150*time.Millisecond),
+		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
+			return StreamErrorStop
+		}))
+	defer func() {
+		if stream != nil {
+			stream.Close()
+		}
+	}()
+	assert.Error(t, err)
+
+	assert.Equal(t, 1, len(requestsCh))
 }
 
 func mustSubscribe(t *testing.T, url string, options ...StreamOption) *Stream {

--- a/stream_test.go
+++ b/stream_test.go
@@ -79,7 +79,7 @@ func TestStreamCanUseErrorHandlerInsteadOfChannelForErrorOnExistingConnection(t 
 	stream := mustSubscribe(t, httpServer.URL,
 		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
 			myErrChannel <- err
-			return StreamErrorProceed
+			return StreamErrorHandlerResult{}
 		}),
 		StreamOptionInitialRetry(time.Millisecond))
 	defer stream.Close()
@@ -118,7 +118,7 @@ func TestStreamErrorHandlerCanPreventRetryOnExistingConnection(t *testing.T) {
 	stream := mustSubscribe(t, httpServer.URL,
 		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
 			myErrChannel <- err
-			return StreamErrorStop
+			return StreamErrorHandlerResult{CloseNow: true}
 		}),
 		StreamOptionInitialRetry(time.Millisecond))
 	defer stream.Close()
@@ -690,7 +690,7 @@ func testStreamErrorHandlerCanAllowRetryOfInitialConnection(t *testing.T, errorH
 		StreamOptionCanRetryFirstConnection(150*time.Millisecond),
 		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
 			myErrChannel <- err
-			return StreamErrorProceed
+			return StreamErrorHandlerResult{}
 		}))
 	defer func() {
 		if stream != nil {
@@ -720,7 +720,7 @@ func TestStreamErrorHandlerCanPreventRetryOfInitialConnection(t *testing.T) {
 		StreamOptionInitialRetry(100*time.Millisecond),
 		StreamOptionCanRetryFirstConnection(150*time.Millisecond),
 		StreamOptionErrorHandler(func(err error) StreamErrorHandlerResult {
-			return StreamErrorStop
+			return StreamErrorHandlerResult{CloseNow: true}
 		}))
 	defer func() {
 		if stream != nil {


### PR DESCRIPTION
This PR adds a new option, `StreamOptionErrorHandler`, and related types, as an alternate way to be notified of stream errors.

Previously, the way to get errors was to consume the channel `stream.Errors`. This had several limitations:

* You had to remember to consume that channel or it would block the stream's goroutine.
* If you enabled retries on the initial connection (`StreamOptionCanRetryFirstConnection`), you would have no way to know about errors that occurred prior to a successful retry (they could not be pushed to the Errors channel, because no one could possibly consume that channel until Subscribe returned the new Stream).
* This was a one-way communication. If you wanted to cause certain errors to terminate the stream instead of causing a retry, you could call `stream.Close()`— but that would be happening some unknown amount of time after the actual error had occurred.

If you specify an error handler, then Stream will _not_ create an Errors channel, but instead will call the handler. The handler returns a value which can tell the stream to shut down immediately.

This is similar to [a mechanism](http://launchdarkly.github.io/okhttp-eventsource/) that we implemented in the Java `okhttp-eventsource` library. It is necessary in order for the LaunchDarkly Go SDK to be able to rely on Stream's standard backoff behavior when starting a stream, since the SDK needs to be able to prevent retries if it gets for instance a 401 error. Previously, the SDK had to implement its own retry behavior for stream initialization errors.