### PR TITLE
add license file, changelog, release metadata

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,0 +1,7 @@
+
+template:
+  name: go
+
+publications:
+  - url: https://godoc.org/github.com/launchdarkly/eventsource
+    description: documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Change log
+
+All notable changes to the project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+
+## [1.3.0] - 2020-03-24
+### Added:
+- New option `StreamOptionUseBackoff` allows `Stream` to be configured to use exponential backoff for reconnections. There was existing logic for exponential backoff, but it was not working, so until now the retry delay was always the same; for backward compatibility with that behavior, the default is still to not use backoff.
+- The new option `StreamOptionRetryResetInterval` can be used in conjunction with `StreamOptionUseBackoff` to determine when, if ever, the retry delay can be reset to its initial value rather than continuing to decrease.
+- New option `StreamOptionUseJitter` tells `Stream` to subtract a pseudo-random amount from the retry delay.
+- New option `StreamOptionCanRetryFirstConnection` tells `Stream` that it can retry the initial connection attempt. Previously, a failed initial connection would be considered a permanent failure.
+
+## [1.2.0] - 2019-06-17
+### Added:
+- `NewDecoderWithOptions` allows creating a `Decoder` with non-default settings; currently the only such setting is `DecoderOptionReadTimeout`. Normally you will not need to create a `Decoder` directly; it is done automatically by `Stream`.
+### Fixed:
+- Reverted an unintentional change in v1.1.0 to the signature of the exported function `NewDecoder`.
+
+## [1.1.0] - 2018-10-03
+### Added:
+- It is now possible to specify a read timeout for a stream. If the stream does not receive new data (either events or comments) within this interval, it will emit an error and restart the connection.
+- New stream constructor methods `SubscribeWithURL` and `SubscribeWithRequestAndOptions` allow any combination of optional configuration parameters to be specified for a stream: read timeout, initial retry delay, last event ID, HTTP client, logger.
+
+## [1.0.1] - 2018-07-20
+### Fixed:
+- Avoid trying to to decode non-200 responses which was generating extra error messages.
+
+## [1.0.0] - 2018-06-14
+Initial release of this fork.
+
+### Added:
+- Added support for Close() method.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to this project
+ 
+## Submitting bug reports and feature requests
+
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/eventsource/issues) in this repository. Bug reports and feature requests specific to this project should be filed in this issue tracker. The SDK team will respond to all newly filed issues within two business days.
+
+Some of this code is used by the LaunchDarkly Go SDK. For issues or requests that are more generally related to the LaunchDarkly Go SDK, rather than specifically for the code in this repository, please use the [`go-server-sdk`](https://github.com/launchdarkly/go-server-sdk) repository.
+ 
+## Submitting pull requests
+ 
+We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly SDK team will add themselves. The SDK team will acknowledge all pull requests within two business days.
+ 
+## Build instructions
+ 
+### Prerequisites
+ 
+This project should be built against Go 1.8 or newer.
+
+### Building
+
+To build the project without running any tests:
+```
+make
+```
+
+To run the linter:
+```
+make lint
+```
+
+### Testing
+ 
+To build and run all unit tests:
+```
+make test
+```

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2020 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
The Apache license was already specified in the readme, but now there's a license file too. The changelog includes all of the releases on GitHub so far.

The `.ldrelease/config.yml` file is for our internal release process. The only difference this makes is to cause our release tool to use a `v` prefix for the release tag, which is a Go convention that has become a requirement for use with Go modules. All release tags from now on will have this prefix.