### PR TITLE
prevent math overflow in backoff calculation

### DIFF
--- a/retry_delay.go
+++ b/retry_delay.go
@@ -1,6 +1,7 @@
 package eventsource
 
 import (
+	"math"
 	"math/rand"
 	"time"
 )
@@ -52,16 +53,8 @@ func newDefaultBackoff(maxDelay time.Duration) backoffStrategy {
 }
 
 func (s defaultBackoffStrategy) applyBackoff(baseDelay time.Duration, retryCount int) time.Duration {
-	// We use repeated multiplication here rather than math.Pow to avoid overflow if retryCount is high. The
-	// overhead of this should be minimal since we're unlikely to iterate many times before hitting the maximum.
-	d := baseDelay
-	for i := 0; i < retryCount; i++ {
-		d *= 2
-		if d > s.maxDelay {
-			return s.maxDelay
-		}
-	}
-	return d
+	d := math.Min(float64(baseDelay)*math.Pow(2, float64(retryCount)), float64(s.maxDelay))
+	return time.Duration(d)
 }
 
 type defaultJitterStrategy struct {


### PR DESCRIPTION
My naive implementation of the backoff logic had the potential to cause not just a wrong result, but a panic, as follows:

* After many retries, `defaultBackoffStrategy.applyBackoff` is called with a high `retryCount` such that `Math.pow(2, retryCount)` produces a `float64` number that's higher than the greatest positive `int64`.
* We then convert this to an `int64` prior to applying the jitter. Due to the overflow this ends up being a negative number.
* Calling `random.Int63n` with this value panics.

The panic would occur on a worker goroutine if an existing connection failed, or on the caller's goroutine if it was retrying the initial connection attempt and had never succeeded. It would happen after about 35 retries if you started from a delay of 1 second.

The faulty logic has not been used in the LaunchDarkly Go SDK yet.