### PR TITLE
update golangci-lint, add CI jobs for multiple Go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ jobs:
       run-lint:
         type: boolean
         default: true
-      work-dir:
-        type: string
-        default: ~/project
 
     docker:
       - image: <<parameters.docker-image>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,70 @@
-version: 2
+version: 2.1
+
+workflows:
+  workflow:
+    jobs:
+      - go-test:
+          name: Go 1.14
+          docker-image: circleci/golang:1.14
+      - go-test:
+          name: Go 1.13
+          docker-image: circleci/golang:1.13
+      - go-test:
+          name: Go 1.12
+          docker-image: circleci/golang:1.12
+      - go-test:
+          name: Go 1.11
+          docker-image: circleci/golang:1.11
+      - go-test:
+          name: Go 1.10
+          docker-image: circleci/golang:1.10
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
+      - go-test:
+          name: Go 1.9
+          docker-image: circleci/golang:1.9
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
+      - go-test:
+          name: Go 1.8
+          docker-image: circleci/golang:1.8
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
 
 jobs:
   go-test:
-    working_directory: /go/src/github.com/launchdarkly/eventsource
+    parameters:
+      docker-image:
+        type: string
+      run-lint:
+        type: boolean
+        default: true
+      work-dir:
+        type: string
+        default: ~/project
 
     docker:
-      - image: circleci/golang:1.9
+      - image: <<parameters.docker-image>>
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circle-reports
-          COMMON_GO_PACKAGES: >
-            github.com/jstemmer/go-junit-report
+
+    working_directory: /go/src/github.com/launchdarkly/eventsource
 
     steps:
       - checkout
-      - run: go get -u $COMMON_GO_PACKAGES
 
-      - run: |
-          mkdir -p $CIRCLE_TEST_REPORTS
-          trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
-          make test | tee output.txt
+      - run:
+          name: install go-junit-report
+          command: go get -u github.com/jstemmer/go-junit-report
 
-      - run: make lint
+      - run:
+          name: build and test
+          command: |
+            mkdir -p $CIRCLE_TEST_REPORTS
+            trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
+            make test | tee output.txt
+
+      - when:
+          condition: <<parameters.run-lint>>
+          steps:
+            - run: make lint
       
       - store_test_results:
           path: /tmp/circle-reports
-
-workflows:
-  version: 2
-  test:
-    jobs:
-      - go-test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - prealloc
     - staticcheck
     - structcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unparam
@@ -43,7 +44,9 @@ linters:
 linters-settings:
   gofmt:
     simplify: false
-
+  goimports:
+    local-prefixes: gopkg.in/launchdarkly,github.com/launchdarkly
+  
 issues:
   exclude-use-default: false
   max-same-issues: 1000

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - whitespace
   fast: false
 
-linter-settings:
+linters-settings:
   gofmt:
     simplify: false
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,41 @@ run:
   tests: false
 
 linters:
-  enable-all: true
-  disable:
-  - maligned
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    - goconst
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
   fast: false
 
 linter-settings:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-GOLANGCI_LINT_VERSION=v1.10.2
-# earlier versions of golangci-lint don't work in go 1.9
+GOLANGCI_LINT_VERSION=v1.27.0
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/decoder.go
+++ b/decoder.go
@@ -13,7 +13,7 @@ type publication struct {
 	retry           int64
 }
 
-//nolint: golint  // should be ID; retained for backward compatibility
+//nolint:golint,stylecheck // should be ID; retained for backward compatibility
 func (s *publication) Id() string    { return s.id }
 func (s *publication) Event() string { return s.event }
 func (s *publication) Data() string  { return s.data }

--- a/decoder.go
+++ b/decoder.go
@@ -115,7 +115,6 @@ ReadLoop:
 			case "id":
 				pub.id = value
 			case "retry":
-				//nolint:gosec
 				pub.retry, _ = strconv.ParseInt(value, 10, 64)
 			}
 		case err := <-dec.errorCh:

--- a/encoder.go
+++ b/encoder.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	encFields = []struct {
+	encFields = []struct { //nolint:gochecknoglobals // non-exported global that we treat as a constant
 		prefix string
 		value  func(Event) string
 	}{

--- a/server.go
+++ b/server.go
@@ -168,7 +168,6 @@ func (srv *Server) run() {
 						srv.unregister <- s
 						close(s.out)
 					}
-
 				}
 			}
 		case sub := <-srv.subs:

--- a/stream.go
+++ b/stream.go
@@ -248,9 +248,7 @@ func (stream *Stream) connect() (io.ReadCloser, error) {
 	}
 	stream.connections++
 	if resp.StatusCode != 200 {
-		//nolint: gosec
 		message, _ := ioutil.ReadAll(resp.Body)
-		//nolint: gosec
 		_ = resp.Body.Close()
 		err = SubscriptionError{
 			Code:    resp.StatusCode,
@@ -312,7 +310,7 @@ NewStream:
 
 		discardCurrentStream := func() {
 			if r != nil {
-				_ = r.Close() //nolint: gosec
+				_ = r.Close()
 				r = nil
 				// allow the decoding goroutine to terminate
 				for range errs {


### PR DESCRIPTION
Note that we never made a specific Go version compatibility statement for this repo. For the upcoming Go SDK 5.0 release, we can make a new version of `eventsource` that drops support for older Go versions, but this PR doesn't do that - we were previously building an old version in CI, so here I'm keeping that and adding builds for all the newer ones.