### PR TITLE
make this repo a module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,91 @@
+version: 2.1
+
+workflows:
+  workflow:
+    jobs:
+      - go-test:
+          name: Go 1.14
+          docker-image: circleci/golang:1.14
+      - go-test:
+          name: Go 1.13
+          docker-image: circleci/golang:1.13
+      - go-test:
+          name: Go 1.12
+          docker-image: circleci/golang:1.12
+          with-modules: false
+          work-dir: /go/src/github.com/launchdarkly/eventsource
+      - go-test:
+          name: Go 1.11
+          docker-image: circleci/golang:1.11
+          with-modules: false
+          work-dir: /go/src/github.com/launchdarkly/eventsource
+      - go-test:
+          name: Go 1.10
+          docker-image: circleci/golang:1.10
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
+          with-modules: false
+          work-dir: /go/src/github.com/launchdarkly/eventsource
+      - go-test:
+          name: Go 1.9
+          docker-image: circleci/golang:1.9
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
+          with-modules: false
+          work-dir: /go/src/github.com/launchdarkly/eventsource
+      - go-test:
+          name: Go 1.8
+          docker-image: circleci/golang:1.8
+          run-lint: false # the version of golangci-lint we're using doesn't work with older Go versions
+          with-modules: false
+          work-dir: /go/src/github.com/launchdarkly/eventsource
+
 version: 2
 
 jobs:
   go-test:
-    working_directory: /go/src/github.com/launchdarkly/eventsource
+    parameters:
+      docker-image:
+        type: string
+      run-lint:
+        type: boolean
+        default: true
+      with-modules:
+        type: boolean
+        default: true
+      work-dir:
+        type: string
+        default: /project
 
     docker:
-      - image: circleci/golang:1.9
+      - image: <<parameters.docker-image>>
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circle-reports
-          COMMON_GO_PACKAGES: >
-            github.com/jstemmer/go-junit-report
+
+    working_directory: <<parameters.work-dir>>
 
     steps:
       - checkout
-      - run: go get -u $COMMON_GO_PACKAGES
 
-      - run: |
-          mkdir -p $CIRCLE_TEST_REPORTS
-          trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
-          make test | tee output.txt
+      - run:
+          name: install go-junit-report
+          command: go get -u github.com/jstemmer/go-junit-report
 
-      - run: make lint
+      - unless:
+          condition: <<parameters.with-modules>>
+          steps:
+            - run: get dependencies
+            - command: go get -t .
+
+      - run:
+          name: build and test
+          command: |
+            mkdir -p $CIRCLE_TEST_REPORTS
+            trap "go-junit-report < output.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
+            make test | tee output.txt
+
+      - when:
+          condition: <<parameters.run-lint>>
+          steps:
+            - run: make lint
       
       - store_test_results:
           path: /tmp/circle-reports
-
-workflows:
-  version: 2
-  test:
-    jobs:
-      - go-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,9 @@ jobs:
       - unless:
           condition: <<parameters.with-modules>>
           steps:
-            - run: get dependencies
-            - command: go get -t .
+            - run:
+                name: get dependencies
+                command: go get -t .
 
       - run:
           name: build and test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ workflows:
           with-modules: false
           work-dir: /go/src/github.com/launchdarkly/eventsource
 
-version: 2
-
 jobs:
   go-test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
         default: true
       work-dir:
         type: string
-        default: /project
+        default: ~/project
 
     docker:
       - image: <<parameters.docker-image>>

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)
 SHELL=/bin/bash
 
 test:
-	go get -t ./...
 	go test -race -v ./...
 
 $(LINTER_VERSION_FILE):

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/launchdarkly/eventsource
+
+go 1.13
+
+require (
+	github.com/launchdarkly/go-test-helpers v1.1.2
+	github.com/stretchr/testify v1.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/launchdarkly/go-test-helpers v1.1.2 h1:Y8Y3+MOf1xFv879FHbpBQJ0dCOimWjPGiq4DWf7CddI=
+github.com/launchdarkly/go-test-helpers v1.1.2/go.mod h1:syxmwe20VkSug3b/t+4e5V1CyUUcT1x6nfWIIF55rj0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This should not affect anyone who's currently consuming this package with dep or govendor.

The import path is still `github.com/launchdarkly/eventsource`. After the next major release, we'll need to add `/v2` to the import path, but Go modules don't require that suffix for v1.