### PR TITLE
add option for enforcing maximum connection lifetime in Server

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 type subscription struct {
@@ -31,11 +32,12 @@ type comment struct {
 // Server manages any number of event-publishing channels and allows subscribers to consume them.
 // To use it within an HTTP server, create a handler for each channel with Handler().
 type Server struct {
-	AllowCORS     bool   // Enable all handlers to be accessible from any origin
-	ReplayAll     bool   // Replay repository even if there's no Last-Event-Id specified
-	BufferSize    int    // How many messages do we let the client get behind before disconnecting
-	Gzip          bool   // Enable compression if client can accept it
-	Logger        Logger // Logger is a logger that, when set, will be used for logging debug messages
+	AllowCORS     bool          // Enable all handlers to be accessible from any origin
+	ReplayAll     bool          // Replay repository even if there's no Last-Event-Id specified
+	BufferSize    int           // How many messages do we let the client get behind before disconnecting
+	Gzip          bool          // Enable compression if client can accept it
+	MaxConnTime   time.Duration // If non-zero, HTTP connections will be automatically closed after this time
+	Logger        Logger        // Logger is a logger that, when set, will be used for logging debug messages
 	registrations chan *registration
 	pub           chan *outbound
 	subs          chan *subscription
@@ -87,6 +89,11 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 			return
 		}
 
+		var maxConnTimeCh <-chan time.Time
+		if srv.MaxConnTime > 0 {
+			maxConnTimeCh = time.After(srv.MaxConnTime)
+		}
+
 		sub := &subscription{
 			channel:     channel,
 			lastEventID: req.Header.Get("Last-Event-ID"),
@@ -102,6 +109,9 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 			select {
 			case <-notifier.CloseNotify():
 				srv.unregister <- sub
+				return
+			case <-maxConnTimeCh: // if MaxConnTime was not set, this is a nil channel so "<-"" is a no-op
+				srv.unregister <- sub // we treat this the same as if the client closed the connection
 				return
 			case ev, ok := <-sub.out:
 				if !ok {

--- a/server_test.go
+++ b/server_test.go
@@ -32,8 +32,8 @@ func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Errorf("Received StatusCode %d, want 200", resp.StatusCode)
 		}
-	case <-time.After(400 * time.Millisecond):
-		break
+	case <-time.After(250 * time.Millisecond):
+		t.Errorf("Did not receive response in time")
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,10 +1,14 @@
 package eventsource
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
@@ -28,7 +32,55 @@ func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Errorf("Received StatusCode %d, want 200", resp.StatusCode)
 		}
-	case <-time.After(250 * time.Millisecond):
-		t.Errorf("Did not receive response in time")
+	case <-time.After(400 * time.Millisecond):
+		break
+	}
+}
+
+func TestServerHandlerHasNoMaxConnectionTimeByDefault(t *testing.T) {
+	server := NewServer()
+	defer server.Close()
+	httpServer := httptest.NewServer(server.Handler("test"))
+	defer httpServer.Close()
+
+	resp, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	readCh := make(chan []byte)
+	go func() {
+		bytes, _ := ioutil.ReadAll(resp.Body)
+		readCh <- bytes
+	}()
+	select {
+	case <-readCh:
+		assert.Fail(t, "Unexpectedly got end of response")
+	case <-time.After(time.Millisecond * 400):
+		break
+	}
+}
+
+func TestServerHandlerCanEnforceMaxConnectionTime(t *testing.T) {
+	server := NewServer()
+	server.MaxConnTime = time.Millisecond * 200
+	defer server.Close()
+	httpServer := httptest.NewServer(server.Handler("test"))
+	defer httpServer.Close()
+
+	startTime := time.Now()
+	resp, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	readCh := make(chan []byte)
+	go func() {
+		bytes, _ := ioutil.ReadAll(resp.Body)
+		readCh <- bytes
+	}()
+	select {
+	case <-readCh:
+		assert.GreaterOrEqual(t, time.Now().Sub(startTime).Milliseconds(), int64(200))
+	case <-time.After(time.Millisecond * 400):
+		assert.Fail(t, "Timed out without response being closed")
 	}
 }


### PR DESCRIPTION
This new field, if set, causes the `eventsource.Server`'s HTTP handler to end a stream after the connection has been up for that amount of time.

This feature is a way of addressing an issue that's sometimes seen with load-balanced clusters of servers (such as LD Relay Proxy instances), where a server that's stayed alive while other instances have been cycled may accumulate a big pile of SSE connections. Assuming that the SSE clients will automatically reconnect if disconnected, dropping connections periodically in this way helps to spread the load around better.