### PR TITLE
add ability to delete a channel + misc concurrency improvements

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -22,6 +22,12 @@ type Event interface {
 type Repository interface {
 	// Gets the Events which should follow on from the specified channel and event id. This method may be called
 	// from different goroutines, so it must be safe for concurrent access.
+	//
+	// It is important for the Repository to close the channel after all the necessary events have been
+	// written to it. The stream will not be able to proceed to any new events until it has finished consuming
+	// the channel that was returned by Replay.
+	//
+	// Replay may return nil if there are no events to be sent.
 	Replay(channel, id string) chan Event
 }
 

--- a/server.go
+++ b/server.go
@@ -137,6 +137,23 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 			return true
 		}
 
+		// The logic below works as follows:
+		// - Normally, the handler is reading from eventCh. Server.run() accesses this channel through sub.out
+		//   and sends published events to it.
+		// - However, if a Repository is being used, the Server might get a whole batch of events that the
+		//   Repository provides through its Replay method. The Repository provides these in the form of a
+		//   channel that it writes to. Since we don't know how many events there will be or how long it will
+		//   take to write them, we do not want to block Server.run() for this.
+		// - Previous implementations of sending events from Replay used a separate goroutine. That was unsafe,
+		//   due to a race condition where Server.run() might close the channel while the Replay goroutine is
+		//   still writing to it.
+		// - So, instead, Server.run() now takes the channel from Replay and wraps it in an eventBatch. When
+		//   the handler sees an eventBatch, it switches over to reading events from that channel until the
+		//   channel is closed. Then it switches back to reading events from the regular channel.
+		// - The Server can close eventCh at any time to indicate that the stream is done. The handler exits.
+		// - If the client closes the connection, or if MaxConnTime elapses, the handler exits after telling
+		//   the Server to stop publishing events to it.
+
 		var readMainCh <-chan eventOrComment = eventCh
 		var readBatchCh <-chan Event
 		closedNormally := false

--- a/server_test.go
+++ b/server_test.go
@@ -22,6 +22,7 @@ func (r *testServerRepository) Replay(channel, id string) chan Event {
 		fakeID = "replayed-from-" + id
 	}
 	out <- &publication{id: fakeID, data: "example"}
+	close(out)
 	return out
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testServerRepository struct{}
+
+func (r *testServerRepository) Replay(channel, id string) chan Event {
+	out := make(chan Event, 1)
+	var fakeID string
+	if id == "" {
+		fakeID = "replayed-from-start"
+	} else {
+		fakeID = "replayed-from-" + id
+	}
+	out <- &publication{id: fakeID, data: "example"}
+	return out
+}
+
 func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 	server := NewServer()
 	httpServer := httptest.NewServer(server.Handler("test"))
@@ -35,6 +49,152 @@ func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Errorf("Did not receive response in time")
 	}
+}
+
+func TestServerHandlerReceivesPublishedEvents(t *testing.T) {
+	channel := "test"
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler(channel))
+	defer httpServer.Close()
+
+	resp1, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	resp2, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	event := &publication{data: "my-event"}
+	ackCh := server.PublishWithAcknowledgment([]string{channel}, event)
+	<-ackCh
+	server.Close()
+
+	expected := "data: my-event\n\n"
+	body1, err := ioutil.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	body2, err := ioutil.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(body1))
+	assert.Equal(t, expected, string(body2))
+}
+
+func TestServerHandlerCanReceiveEventsFromRepository(t *testing.T) {
+	channel := "test"
+	repo := &testServerRepository{}
+
+	t.Run("events are not replayed if ReplayAll is false and Last-Event-Id is not specified", func(t *testing.T) {
+		server := NewServer()
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Len(t, body, 0)
+	})
+
+	t.Run("all events are replayed if ReplayAll is true", func(t *testing.T) {
+		server := NewServer()
+		server.ReplayAll = true
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "id: replayed-from-start\ndata: example\n\n", string(body))
+	})
+
+	t.Run("events are replayed selectively if ReplayAll is false and Last-Event-Id is specified", func(t *testing.T) {
+		server := NewServer()
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		req, err := http.NewRequest("GET", httpServer.URL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Last-Event-Id", "some-id")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "id: replayed-from-some-id\ndata: example\n\n", string(body))
+	})
+
+	t.Run("repository is no longer used after being unregistered", func(t *testing.T) {
+		server := NewServer()
+		server.ReplayAll = true
+		server.Register(channel, repo)
+		server.Unregister(channel, false)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Len(t, body, 0)
+	})
+}
+
+func TestServerCanDisconnectClientsWhenUnregisteringRepository(t *testing.T) {
+	channel := "test"
+	repo := &testServerRepository{}
+	server := NewServer()
+	server.Register(channel, repo)
+
+	httpServer := httptest.NewServer(server.Handler(channel))
+	defer httpServer.Close()
+
+	resp1, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	resp2, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	event1 := &publication{data: "my-event1"}
+	ackCh := server.PublishWithAcknowledgment([]string{channel}, event1)
+	<-ackCh
+	server.Unregister(channel, true)
+
+	event2 := &publication{data: "my-event2"}
+	ackCh = server.PublishWithAcknowledgment([]string{channel}, event2)
+	<-ackCh
+
+	server.Close()
+
+	expected := "data: my-event1\n\n"
+	body1, err := ioutil.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	body2, err := ioutil.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(body1))
+	assert.Equal(t, expected, string(body2))
 }
 
 func TestServerHandlerHasNoMaxConnectionTimeByDefault(t *testing.T) {


### PR DESCRIPTION
There are two new features in this PR:

1. `Server.Unregister(channel, forceDisconnect)` removes any `Repository` that was associated with that channel, and, if `forceDisconnect` is true, causes any current subscribers on that channel to be dropped. This is needed in cases where stream requests use some kind of credential which might need to be invalidated at some point.

2. `Server.PublishWithAcknowledgement(channels, event)` is the same as `Publish`, but returns a channel that will tell the caller when the event has actually been published (that is, when it has been picked up on the main server loop and pushed to the subscribers; it doesn't mean they have actually read it). This allows there to be a well-defined ordering of actions if you want to, for instance, publish an event and then close the channel; otherwise, since those actions are dispatched on different channels, the indeterminacy of `select` means the close might happen first. The immediate reason for adding this method was that otherwise some test scenarios would be hard to test reliably, but I decided to export and support it because it's a reasonable thing for applications to want to do.

There are some other improvements:

* Fixed a race condition where the main `Server.run()` goroutine might close a subscriber's channel while we are trying to write to that same channel on another goroutine— the latter being one that we spun off in order to replay events from a Repository, because we don't know how long the replay will take (the Repository returns a channel which it can write as many events to as it wants, for however long it wants) and don't want to block the main loop. My approach was to push a new type of message onto the subscriber channel that is a batch, wrapping the channel that the Repository provided, which the subscriber will then read while the main Server loop goes on its merry way.
* We didn't have much test coverage for Server, which is why that race condition wasn't noticed. There's more now.