### PR TITLE
use Context instead of CloseNotifier to detect when a request was cancelled

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -22,6 +22,12 @@ type Event interface {
 type Repository interface {
 	// Gets the Events which should follow on from the specified channel and event id. This method may be called
 	// from different goroutines, so it must be safe for concurrent access.
+	//
+	// It is important for the Repository to close the channel after all the necessary events have been
+	// written to it. The stream will not be able to proceed to any new events until it has finished consuming
+	// the channel that was returned by Replay.
+	//
+	// Replay may return nil if there are no events to be sent.
 	Replay(channel, id string) chan Event
 }
 

--- a/server.go
+++ b/server.go
@@ -120,8 +120,6 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 		}
 		srv.subs <- sub
 		flusher := w.(http.Flusher)
-		//nolint: megacheck  // http.CloseNotifier is deprecated, but currently we are retaining compatibility with Go 1.7
-		notifier := w.(http.CloseNotifier)
 		flusher.Flush()
 		enc := NewEncoder(w, useGzip)
 
@@ -140,11 +138,12 @@ func (srv *Server) Handler(channel string) http.HandlerFunc {
 		var readMainCh <-chan eventOrComment = eventCh
 		var readBatchCh <-chan Event
 		closedNormally := false
+		closeNotify := req.Context().Done()
 
 	ReadLoop:
 		for {
 			select {
-			case <-notifier.CloseNotify():
+			case <-closeNotify:
 				break ReadLoop
 			case <-maxConnTimeCh: // if MaxConnTime was not set, this is a nil channel and has no effect on the select
 				break ReadLoop

--- a/server_test.go
+++ b/server_test.go
@@ -22,6 +22,7 @@ func (r *testServerRepository) Replay(channel, id string) chan Event {
 		fakeID = "replayed-from-" + id
 	}
 	out <- &publication{id: fakeID, data: "example"}
+	close(out)
 	return out
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testServerRepository struct{}
+
+func (r *testServerRepository) Replay(channel, id string) chan Event {
+	out := make(chan Event, 1)
+	var fakeID string
+	if id == "" {
+		fakeID = "replayed-from-start"
+	} else {
+		fakeID = "replayed-from-" + id
+	}
+	out <- &publication{id: fakeID, data: "example"}
+	return out
+}
+
 func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 	server := NewServer()
 	httpServer := httptest.NewServer(server.Handler("test"))
@@ -35,6 +49,152 @@ func TestNewServerHandlerRespondsAfterClose(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Errorf("Did not receive response in time")
 	}
+}
+
+func TestServerHandlerReceivesPublishedEvents(t *testing.T) {
+	channel := "test"
+	server := NewServer()
+	httpServer := httptest.NewServer(server.Handler(channel))
+	defer httpServer.Close()
+
+	resp1, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	resp2, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	event := &publication{data: "my-event"}
+	ackCh := server.PublishWithAcknowledgment([]string{channel}, event)
+	<-ackCh
+	server.Close()
+
+	expected := "data: my-event\n\n"
+	body1, err := ioutil.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	body2, err := ioutil.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(body1))
+	assert.Equal(t, expected, string(body2))
+}
+
+func TestServerHandlerCanReceiveEventsFromRepository(t *testing.T) {
+	channel := "test"
+	repo := &testServerRepository{}
+
+	t.Run("events are not replayed if ReplayAll is false and Last-Event-Id is not specified", func(t *testing.T) {
+		server := NewServer()
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Len(t, body, 0)
+	})
+
+	t.Run("all events are replayed if ReplayAll is true", func(t *testing.T) {
+		server := NewServer()
+		server.ReplayAll = true
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "id: replayed-from-start\ndata: example\n\n", string(body))
+	})
+
+	t.Run("events are replayed selectively if ReplayAll is false and Last-Event-Id is specified", func(t *testing.T) {
+		server := NewServer()
+		server.Register(channel, repo)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		req, err := http.NewRequest("GET", httpServer.URL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Last-Event-Id", "some-id")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "id: replayed-from-some-id\ndata: example\n\n", string(body))
+	})
+
+	t.Run("repository is no longer used after being unregistered", func(t *testing.T) {
+		server := NewServer()
+		server.ReplayAll = true
+		server.Register(channel, repo)
+		server.Unregister(channel, false)
+
+		httpServer := httptest.NewServer(server.Handler(channel))
+		defer httpServer.Close()
+
+		resp, err := http.Get(httpServer.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		server.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Len(t, body, 0)
+	})
+}
+
+func TestServerCanDisconnectClientsWhenUnregisteringRepository(t *testing.T) {
+	channel := "test"
+	repo := &testServerRepository{}
+	server := NewServer()
+	server.Register(channel, repo)
+
+	httpServer := httptest.NewServer(server.Handler(channel))
+	defer httpServer.Close()
+
+	resp1, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	resp2, err := http.Get(httpServer.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	event1 := &publication{data: "my-event1"}
+	ackCh := server.PublishWithAcknowledgment([]string{channel}, event1)
+	<-ackCh
+	server.Unregister(channel, true)
+
+	event2 := &publication{data: "my-event2"}
+	ackCh = server.PublishWithAcknowledgment([]string{channel}, event2)
+	<-ackCh
+
+	server.Close()
+
+	expected := "data: my-event1\n\n"
+	body1, err := ioutil.ReadAll(resp1.Body)
+	require.NoError(t, err)
+	body2, err := ioutil.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(body1))
+	assert.Equal(t, expected, string(body2))
 }
 
 func TestServerHandlerHasNoMaxConnectionTimeByDefault(t *testing.T) {


### PR DESCRIPTION
The `http.CloseNotifier` interface was a hacky and deprecated way to find out if an HTTP request was cancelled by the client. It was being used here because this library was trying to maintain compatibility with very old Go; we no longer need to do that.

As a side benefit, I believe that this makes it possible to test `Server` with `httptest.ResponseRecorder`. Previously you couldn't, because `ResponseRecorder` did not implement `CloseNotifier` and it would panic when it tried to do the typecast.

I added test coverage, which we didn't previously have for the cancelled-request case.