### PR TITLE
discard event ID field if it contains a null

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -113,7 +113,9 @@ ReadLoop:
 			case "data":
 				pub.data += value + "\n"
 			case "id":
-				pub.id = value
+				if !strings.ContainsRune(value, 0) {
+					pub.id = value
+				}
 			case "retry":
 				pub.retry, _ = strconv.ParseInt(value, 10, 64)
 			}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -21,6 +21,15 @@ func TestDecode(t *testing.T) {
 			rawInput:     "\n\n\nevent: event1\n\n\n\n\nevent: event2\n\n",
 			wantedEvents: []*publication{{event: "event1"}, {event: "event2"}},
 		},
+		{
+			rawInput:     "id: abc\ndata: def\n\n",
+			wantedEvents: []*publication{{id: "abc", data: "def"}},
+		},
+		{
+			// id field should be ignored if it contains a null
+			rawInput:     "id: a\x00bc\ndata: def\n\n",
+			wantedEvents: []*publication{{data: "def"}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation): "If the field name is "id" ... If the field value does not contain U+0000 NULL, then set the last event ID buffer to the field value. Otherwise, ignore the field."

I believe the reason for this is that the field value might later be copied into a Last-Event-Id header, and HTTP header values cannot contain nulls.

A test for this is added to the SSE contract tests in https://github.com/launchdarkly/sse-contract-tests/pull/6.