### PR TITLE
add ability to get last event ID in every event, for spec compliance

### DIFF
--- a/contract-tests/service.go
+++ b/contract-tests/service.go
@@ -73,6 +73,7 @@ func main() {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	})
+	fmt.Println("Listening on port 8000")
 	server := &http.Server{Handler: mux, Addr: ":8000"}
 	_ = server.ListenAndServe()
 }

--- a/contract-tests/stream_entity.go
+++ b/contract-tests/stream_entity.go
@@ -74,14 +74,14 @@ func newStreamEntity(opts streamOpts) *streamEntity {
 				if ev == nil {
 					return
 				}
-				id := ev.Id()
-				if evWithLastID, ok := ev.(eventsource.EventWithLastID); ok {
-					id = evWithLastID.LastEventID()
-				}
 				evProps := jsonObject{
 					"type": ev.Event(),
 					"data": ev.Data(),
-					"id":   id,
+					"id":   ev.(eventsource.EventWithLastID).LastEventID(),
+					// Note that the cast above will panic if the event does not implement EventWithLastID. Every
+					// event returned by the eventsource client *does* implement that interface - it is only a
+					// separate interface because, for backward compatibility, we could not add a method to Event.
+					// So if such a panic happened, it would correctly indicate that we broke something.
 				}
 				e.logger.Printf("Received event from stream (%s)", ev.Event())
 				e.sendMessage(jsonObject{"kind": "event", "event": evProps})

--- a/contract-tests/stream_entity.go
+++ b/contract-tests/stream_entity.go
@@ -74,10 +74,14 @@ func newStreamEntity(opts streamOpts) *streamEntity {
 				if ev == nil {
 					return
 				}
+				id := ev.Id()
+				if evWithLastID, ok := ev.(eventsource.EventWithLastID); ok {
+					id = evWithLastID.LastEventID()
+				}
 				evProps := jsonObject{
 					"type": ev.Event(),
 					"data": ev.Data(),
-					"id":   ev.Id(),
+					"id":   id,
 				}
 				e.logger.Printf("Received event from stream (%s)", ev.Event())
 				e.sendMessage(jsonObject{"kind": "event", "event": evProps})

--- a/decoder.go
+++ b/decoder.go
@@ -9,8 +9,8 @@ import (
 )
 
 type publication struct {
-	id, event, data string
-	retry           int64
+	id, event, data, lastEventID string
+	retry                        int64
 }
 
 //nolint:golint,stylecheck // should be ID; retained for backward compatibility
@@ -19,11 +19,15 @@ func (s *publication) Event() string { return s.event }
 func (s *publication) Data() string  { return s.data }
 func (s *publication) Retry() int64  { return s.retry }
 
+// LastEventID is from a separate interface, EventWithLastID
+func (s *publication) LastEventID() string { return s.lastEventID }
+
 // A Decoder is capable of reading Events from a stream.
 type Decoder struct {
 	linesCh     <-chan string
 	errorCh     <-chan error
 	readTimeout time.Duration
+	lastEventID string
 }
 
 // DecoderOption is a common interface for optional configuration parameters that can be
@@ -38,11 +42,24 @@ func (o readTimeoutDecoderOption) apply(d *Decoder) {
 	d.readTimeout = time.Duration(o)
 }
 
+type lastEventIDDecoderOption string
+
+func (o lastEventIDDecoderOption) apply(d *Decoder) {
+	d.lastEventID = string(o)
+}
+
 // DecoderOptionReadTimeout returns an option that sets the read timeout interval for a
 // Decoder when the Decoder is created. If the Decoder does not receive new data within this
 // length of time, it will return an error. By default, there is no read timeout.
 func DecoderOptionReadTimeout(timeout time.Duration) DecoderOption {
 	return readTimeoutDecoderOption(timeout)
+}
+
+// DecoderOptionLastEventID returns an option that sets the last event ID property for a
+// Decoder when the Decoder is created. This allows the last ID to be included in new
+// events if they do not override it.
+func DecoderOptionLastEventID(lastEventID string) DecoderOption {
+	return lastEventIDDecoderOption(lastEventID)
 }
 
 // NewDecoder returns a new Decoder instance that reads events with the given io.Reader.
@@ -114,6 +131,7 @@ ReadLoop:
 				pub.data += value + "\n"
 			case "id":
 				pub.id = value
+				dec.lastEventID = value
 			case "retry":
 				pub.retry, _ = strconv.ParseInt(value, 10, 64)
 			}
@@ -131,6 +149,7 @@ ReadLoop:
 		}
 	}
 	pub.data = strings.TrimSuffix(pub.data, "\n")
+	pub.lastEventID = dec.lastEventID
 	return pub, nil
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -25,7 +25,7 @@ func TestDecode(t *testing.T) {
 		},
 		{
 			rawInput:     "id: abc\ndata: def\n\n",
-			wantedEvents: []*publication{{id: "abc", data: "def"}},
+			wantedEvents: []*publication{{id: "abc", lastEventID: "abc", data: "def"}},
 		},
 		{
 			// id field should be ignored if it contains a null
@@ -35,9 +35,9 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		decoder := NewDecoder(strings.NewReader(test.rawInput))
 		i := 0
 		for {
-			decoder := NewDecoder(strings.NewReader(test.rawInput))
 			event, err := decoder.Decode()
 			if err == io.EOF {
 				break

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -35,9 +35,9 @@ func TestDecode(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		decoder := NewDecoder(strings.NewReader(test.rawInput))
 		i := 0
 		for {
+			decoder := NewDecoder(strings.NewReader(test.rawInput))
 			event, err := decoder.Decode()
 			if err == io.EOF {
 				break

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2,9 +2,11 @@ package eventsource
 
 import (
 	"io"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecode(t *testing.T) {
@@ -31,17 +33,102 @@ func TestDecode(t *testing.T) {
 			if err == io.EOF {
 				break
 			}
-			if err != nil {
-				t.Fatalf("Unexpected error on decoding event: %s", err)
-			}
-
-			if !reflect.DeepEqual(event, test.wantedEvents[i]) {
-				t.Fatalf("Parsed event %+v does not equal wanted event %+v", event, test.wantedEvents[i])
-			}
+			require.NoError(t, err, "for input: %q", test.rawInput)
+			assert.Equal(t, test.wantedEvents[i], event, "for input: %q", test.rawInput)
 			i++
 		}
-		if i != len(test.wantedEvents) {
-			t.Fatalf("Unexpected number of events: %d does not equal wanted: %d", i, len(test.wantedEvents))
-		}
+		assert.Equal(t, len(test.wantedEvents), i, "Wrong number of decoded events")
 	}
+}
+
+func requireLastEventID(t *testing.T, event Event) string {
+	// necessary because we can't yet add LastEventID to the basic Event interface; see EventWithLastID
+	eventWithID, ok := event.(EventWithLastID)
+	require.True(t, ok, "event should have implemented EventWithLastID")
+	return eventWithID.LastEventID()
+}
+
+func TestDecoderTracksLastEventID(t *testing.T) {
+	t.Run("uses last ID that is passed in options", func(t *testing.T) {
+		inputData := "data: abc\n\n"
+		decoder := NewDecoderWithOptions(strings.NewReader(inputData), DecoderOptionLastEventID("my-id"))
+
+		event, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "abc", event.Data())
+		assert.Equal(t, "", event.Id())
+		assert.Equal(t, "my-id", requireLastEventID(t, event))
+	})
+
+	t.Run("last ID persists if not overridden", func(t *testing.T) {
+		inputData := "id: abc\ndata: first\n\ndata: second\n\nid: def\ndata:third\n\n"
+		decoder := NewDecoderWithOptions(strings.NewReader(inputData), DecoderOptionLastEventID("my-id"))
+
+		event1, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", event1.Data())
+		assert.Equal(t, "abc", event1.Id())
+		assert.Equal(t, "abc", requireLastEventID(t, event1))
+
+		event2, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", event2.Data())
+		assert.Equal(t, "", event2.Id())
+		assert.Equal(t, "abc", requireLastEventID(t, event2))
+
+		event3, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "third", event3.Data())
+		assert.Equal(t, "def", event3.Id())
+		assert.Equal(t, "def", requireLastEventID(t, event3))
+	})
+
+	t.Run("last ID persists if not overridden", func(t *testing.T) {
+		inputData := "id: abc\ndata: first\n\ndata: second\n\nid: def\ndata:third\n\n"
+		decoder := NewDecoderWithOptions(strings.NewReader(inputData), DecoderOptionLastEventID("my-id"))
+
+		event1, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", event1.Data())
+		assert.Equal(t, "abc", event1.Id())
+		assert.Equal(t, "abc", requireLastEventID(t, event1))
+
+		event2, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", event2.Data())
+		assert.Equal(t, "", event2.Id())
+		assert.Equal(t, "abc", requireLastEventID(t, event2))
+
+		event3, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "third", event3.Data())
+		assert.Equal(t, "def", event3.Id())
+		assert.Equal(t, "def", requireLastEventID(t, event3))
+	})
+
+	t.Run("last ID can be overridden with empty string", func(t *testing.T) {
+		inputData := "id: abc\ndata: first\n\nid: \ndata: second\n\n"
+		decoder := NewDecoderWithOptions(strings.NewReader(inputData), DecoderOptionLastEventID("my-id"))
+
+		event1, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", event1.Data())
+		assert.Equal(t, "abc", event1.Id())
+		assert.Equal(t, "abc", requireLastEventID(t, event1))
+
+		event2, err := decoder.Decode()
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", event2.Data())
+		assert.Equal(t, "", event2.Id())
+		assert.Equal(t, "", requireLastEventID(t, event2))
+	})
 }

--- a/interface.go
+++ b/interface.go
@@ -17,6 +17,21 @@ type Event interface {
 	Data() string
 }
 
+// EventWithLastID is an additional interface for an event received by the client,
+// allowing access to the LastEventID method.
+//
+// This is defined as a separate interface for backward compatibility, since this
+// feature was added after the Event interface had been defined and adding a method
+// to Event would break existing implementations. All events returned by Stream do
+// implement this interface, and in a future major version the Event type will be
+// changed to always include this field.
+type EventWithLastID interface {
+	// LastEventID is the value of the `id:` field that was most recently seen in an event
+	// from this stream, if any. This differs from Event.Id() in that it retains the same
+	// value in subsequent events if they do not provide their own `id:` field.
+	LastEventID() string
+}
+
 // Repository is an interface to be used with Server.Register() allowing clients to replay previous events
 // through the server, if history is required.
 type Repository interface {

--- a/stream.go
+++ b/stream.go
@@ -292,7 +292,10 @@ NewStream:
 		errs := make(chan error)
 
 		if r != nil {
-			dec := NewDecoderWithOptions(r, DecoderOptionReadTimeout(stream.readTimeout))
+			dec := NewDecoderWithOptions(r,
+				DecoderOptionReadTimeout(stream.readTimeout),
+				DecoderOptionLastEventID(stream.lastEventID),
+			)
 			go func() {
 				for {
 					ev, err := dec.Decode()
@@ -338,9 +341,7 @@ NewStream:
 				if pub.Retry() > 0 {
 					stream.retryDelay.SetBaseDelay(time.Duration(pub.Retry()) * time.Millisecond)
 				}
-				if len(pub.Id()) > 0 {
-					stream.lastEventID = pub.Id()
-				}
+				stream.lastEventID = pub.lastEventID
 				stream.retryDelay.SetGoodSince(time.Now())
 				stream.Events <- ev
 			case <-stream.closer:

--- a/stream_reading_test.go
+++ b/stream_reading_test.go
@@ -23,7 +23,7 @@ func TestStreamSubscribeEventsChan(t *testing.T) {
 
 	select {
 	case receivedEvent := <-stream.Events:
-		assert.Equal(t, &publication{id: "123"}, receivedEvent)
+		assert.Equal(t, &publication{id: "123", lastEventID: "123"}, receivedEvent)
 	case <-time.After(timeToWaitForEvent):
 		t.Error("Timed out waiting for event")
 	}

--- a/stream_reconnect_test.go
+++ b/stream_reconnect_test.go
@@ -49,7 +49,7 @@ func TestStreamReconnectsIfConnectionIsBroken(t *testing.T) {
 			t.Error("Timed out waiting for event")
 			return
 		case receivedEvent := <-stream.Events:
-			assert.Equal(t, &publication{id: "123"}, receivedEvent)
+			assert.Equal(t, &publication{id: "123", lastEventID: "123"}, receivedEvent)
 			return
 		}
 	}

--- a/stream_restart_close_test.go
+++ b/stream_restart_close_test.go
@@ -33,14 +33,14 @@ func TestStreamRestart(t *testing.T) {
 	eventIn1 := httphelpers.SSEEvent{ID: "123"}
 	streamControl1.Enqueue(eventIn1)
 	eventOut1 := <-stream.Events
-	assert.Equal(t, toPublication(eventIn1), eventOut1)
+	assert.Equal(t, "123", eventOut1.Id())
 
 	stream.Restart()
 
 	eventIn2 := httphelpers.SSEEvent{ID: "456"}
 	streamControl2.Enqueue(eventIn2)
 	eventOut2 := <-stream.Events // received an event from streamHandler2
-	assert.Equal(t, toPublication(eventIn2), eventOut2)
+	assert.Equal(t, "456", eventOut2.Id())
 
 	assert.Equal(t, 0, len(stream.Errors)) // restart is not reported as an error
 }


### PR DESCRIPTION
SSE clients are supposed to keep track of the last `id:` value seen in an event, if any— not counting events that didn't have such a field— and copy this to 1. the `Last-Event-Id` header of any subsequent retry request, and 2. a field in all subsequent returned events.

Our current implementation does 1, but not 2. That is, the `Id` in the returned events is only the `id:` value of that event. This doesn't affect our use of SSE in LaunchDarkly,  because we never set the `id:` field, but it is noncompliant with the spec.

(Note: for backward compatibility, we need to maintain that behavior for Id and add a new method that provides the correct behavior. Unfortunately, the original implementation used an interface type for the returned `Event`, so we can't just add a struct field. I think in a future major version, it'd be good to change `Event` to a struct for returned events. It still makes sense to use an interface when _sending_ events with the SSE _server_ implementation that's in this package, in case you have some kind of lazily-computed data, but there's no reason we need to use the same type for sending and receiving— the semantics are not really the same, since this "retain the last ID" behavior only applies when receiving.)

Tests for this are added to the SSE contract tests in https://github.com/launchdarkly/sse-contract-tests/pull/6.