### PR TITLE
update to v2 of sse-contract-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ start-contract-test-service-bg:
 	@make start-contract-test-service >$(TEMP_TEST_OUTPUT) 2>&1 &
 
 run-contract-tests:
-	@curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v1.0.0/downloader/run.sh \
-      | VERSION=v1 PARAMS="-url http://localhost:8000 -debug -stop-service-at-end" sh
+	@curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v2.0.0/downloader/run.sh \
+      | VERSION=v2 PARAMS="-url http://localhost:8000 -debug -stop-service-at-end" sh
 
 contract-tests: build-contract-tests start-contract-test-service-bg run-contract-tests
 


### PR DESCRIPTION
This ensures that the fixes in https://github.com/launchdarkly/eventsource/pull/30 and https://github.com/launchdarkly/eventsource/pull/31— as well as other recently added contract tests that didn't require fixes here, because they were already working— are always tested in CI over and above our unit test coverage.

We don't need to update this every time a new test is added in another v2.x release of sse-contract-tests; in this case we have to update from v1 to v2 because there were some backward-incompatible changes.