### PR TITLE
add Encoder test coverage and fix edge case for empty data

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -9,12 +9,13 @@ import (
 
 var (
 	encFields = []struct { //nolint:gochecknoglobals // non-exported global that we treat as a constant
-		prefix string
-		value  func(Event) string
+		prefix   string
+		value    func(Event) string
+		required bool
 	}{
-		{"id: ", Event.Id},
-		{"event: ", Event.Event},
-		{"data: ", Event.Data},
+		{"id: ", Event.Id, false},
+		{"event: ", Event.Event, false},
+		{"data: ", Event.Data, true},
 	}
 )
 
@@ -42,7 +43,7 @@ func (enc *Encoder) Encode(ec eventOrComment) error {
 	case Event:
 		for _, field := range encFields {
 			prefix, value := field.prefix, field.value(item)
-			if len(value) == 0 {
+			if len(value) == 0 && !field.required {
 				continue
 			}
 			for _, s := range strings.Split(value, "\n") {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,111 @@
+package eventsource
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type encoderTestCase struct {
+	event    publication
+	expected string
+}
+
+type writerWithOnlyWriteMethod struct {
+	buf *bytes.Buffer
+}
+
+func (w *writerWithOnlyWriteMethod) Write(data []byte) (int, error) {
+	return w.buf.Write(data)
+}
+
+func TestEncoderOmitsOptionalFieldsWithoutValues(t *testing.T) {
+	for _, tc := range []encoderTestCase{
+		{publication{data: "aaa"}, "data: aaa\n\n"},
+		{publication{event: "aaa", data: "bbb"}, "event: aaa\ndata: bbb\n\n"},
+		{publication{id: "aaa", data: "bbb"}, "id: aaa\ndata: bbb\n\n"},
+		{publication{id: "aaa", event: "bbb", data: "ccc"}, "id: aaa\nevent: bbb\ndata: ccc\n\n"},
+
+		// An SSE message must *always* have a data field, even if its value is empty.
+		{publication{data: ""}, "data: \n\n"},
+	} {
+		t.Run(fmt.Sprintf("%+v", tc.event), func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			NewEncoder(buf, false).Encode(&tc.event)
+			assert.Equal(t, tc.expected, string(buf.Bytes()))
+		})
+	}
+}
+
+func TestEncoderMultiLineData(t *testing.T) {
+	for _, tc := range []encoderTestCase{
+		{publication{data: "\nfirst"}, "data: \ndata: first\n\n"},
+		{publication{data: "first\nsecond"}, "data: first\ndata: second\n\n"},
+		{publication{data: "first\nsecond\nthird"}, "data: first\ndata: second\ndata: third\n\n"},
+		{publication{data: "ends with newline\n"}, "data: ends with newline\ndata: \n\n"},
+		{publication{data: "first\nends with newline\n"}, "data: first\ndata: ends with newline\ndata: \n\n"},
+	} {
+		t.Run(fmt.Sprintf("%+v", tc.event), func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			NewEncoder(buf, false).Encode(&tc.event)
+			assert.Equal(t, tc.expected, string(buf.Bytes()))
+		})
+	}
+}
+
+func TestEncoderComment(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	c := comment{value: "hello"}
+	NewEncoder(buf, false).Encode(c)
+	assert.Equal(t, ":hello\n", string(buf.Bytes()))
+}
+
+func TestEncoderGzipCompression(t *testing.T) {
+	uncompressedBuf, compressedBuf, expectedCompressedBuf := bytes.NewBuffer(nil), bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+
+	event := &publication{
+		event: "aaa",
+		data:  "bbb",
+	}
+
+	NewEncoder(uncompressedBuf, false).Encode(event)
+	zipper := gzip.NewWriter(expectedCompressedBuf)
+	zipper.Write(uncompressedBuf.Bytes())
+	zipper.Flush()
+
+	NewEncoder(compressedBuf, true).Encode(event)
+	assert.Equal(t, expectedCompressedBuf.Bytes(), compressedBuf.Bytes())
+}
+
+func TestEncoderCanWriteToWriterWithOrWithoutWriteStringMethod(t *testing.T) {
+	// We're using bufio.WriteString, so that we should get consistent output regardless of whether
+	// the underlying Writer supports the WriteString method (as the standard http.ResponseWriter
+	// does), but that is an implementation detail so this test verifies that it really does work.
+	doTest := func(t *testing.T, withWriteString bool) {
+		var w io.Writer
+		buf := bytes.NewBuffer(nil)
+		if withWriteString {
+			w = bufio.NewWriter(buf)
+		} else {
+			w = &writerWithOnlyWriteMethod{buf: buf}
+		}
+		enc := NewEncoder(w, false)
+		enc.Encode(&publication{
+			id:    "aaa",
+			event: "bbb",
+			data:  "ccc",
+		})
+		if withWriteString {
+			w.(*bufio.Writer).Flush()
+		}
+		assert.Equal(t, "id: aaa\nevent: bbb\ndata: ccc\n\n", string(buf.Bytes()))
+	}
+
+	t.Run("with WriteString", func(t *testing.T) { doTest(t, true) })
+	t.Run("without WriteString", func(t *testing.T) { doTest(t, false) })
+}


### PR DESCRIPTION
The logic that was modified by https://github.com/launchdarkly/eventsource/pull/35 never really had good test coverage— it's exercised as part of the Server tests, but that only covered some simple cases. Even though the Encoder implementation is fairly simple, we should have coverage.

And, it turns out there was already an unrelated problem: technically it should be possible to send an event with _no_ data, but to do so, you need to write an empty `data:` field— SSE clients will not process the event otherwise.

I'll merge the `contrib` branch and release once this is merged.