### PR TITLE
Update event interface to use io.Reader over simple strings

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -2,23 +2,35 @@ package eventsource
 
 import (
 	"bytes"
+	"io"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testEvent struct {
 	id, event, data string
 }
 
-func (e *testEvent) Id() string    { return e.id }
-func (e *testEvent) Event() string { return e.event }
-func (e *testEvent) Data() string  { return e.data }
+func newTestEvent(id, event, data string) *testEvent {
+	return &testEvent{
+		id:    id,
+		event: event,
+		data:  data,
+	}
+}
+
+func (e *testEvent) Id() string           { return e.id }
+func (e *testEvent) Event() string        { return e.event }
+func (e *testEvent) GetReader() io.Reader { return strings.NewReader(e.data) }
 
 var encoderTests = []struct {
 	event  *testEvent
 	output string
 }{
-	{&testEvent{"1", "Add", "This is a test"}, "id: 1\nevent: Add\ndata: This is a test\n\n"},
-	{&testEvent{"", "", "This message, it\nhas two lines."}, "data: This message, it\ndata: has two lines.\n\n"},
+	{newTestEvent("1", "Add", "This is a test"), "id: 1\nevent: Add\ndata: This is a test\n\n"},
+	{newTestEvent("", "", "This message, it\nhas two lines."), "data: This message, it\ndata: has two lines.\n\n"},
 }
 
 func TestRoundTrip(t *testing.T) {
@@ -37,8 +49,15 @@ func TestRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ev.Id() != want.Id() || ev.Event() != want.Event() || ev.Data() != want.Data() {
-			t.Errorf("Expected: %s %s %s Got: %s %s %s", want.Id(), want.Event(), want.Data(), ev.Id(), ev.Event(), ev.Data())
+
+		evData, err := io.ReadAll(ev.GetReader())
+		assert.NoError(t, err)
+
+		wantData, err := io.ReadAll(want.GetReader())
+		assert.NoError(t, err)
+
+		if ev.Id() != want.Id() || ev.Event() != want.Event() || !bytes.Equal(evData, wantData) {
+			t.Errorf("Expected: '%s' '%s' '%s' Got: '%s' '%s' '%s'", want.Id(), want.Event(), string(wantData), ev.Id(), ev.Event(), string(evData))
 		}
 	}
 }

--- a/contract-tests/stream_entity.go
+++ b/contract-tests/stream_entity.go
@@ -74,9 +74,13 @@ func newStreamEntity(opts streamOpts) *streamEntity {
 				if ev == nil {
 					return
 				}
+				evData, err := io.ReadAll(ev.GetReader())
+				if err != nil {
+					e.logger.Printf("Failed to read event body (%s)", ev.Event())
+				}
 				evProps := jsonObject{
 					"type": ev.Event(),
-					"data": ev.Data(),
+					"data": string(evData),
 					"id":   ev.(eventsource.EventWithLastID).LastEventID(),
 					// Note that the cast above will panic if the event does not implement EventWithLastID. Every
 					// event returned by the eventsource client *does* implement that interface - it is only a

--- a/decoder.go
+++ b/decoder.go
@@ -13,11 +13,20 @@ type publication struct {
 	retry                        int64
 }
 
+func newPublicationEvent(id, event, lastEventID, data string) *publication {
+	return &publication{
+		id:          id,
+		event:       event,
+		lastEventID: lastEventID,
+		data:        data,
+	}
+}
+
 //nolint:golint,stylecheck // should be ID; retained for backward compatibility
-func (s *publication) Id() string    { return s.id }
-func (s *publication) Event() string { return s.event }
-func (s *publication) Data() string  { return s.data }
-func (s *publication) Retry() int64  { return s.retry }
+func (s *publication) Id() string           { return s.id }
+func (s *publication) Event() string        { return s.event }
+func (s *publication) GetReader() io.Reader { return strings.NewReader(s.data) }
+func (s *publication) Retry() int64         { return s.retry }
 
 // LastEventID is from a separate interface, EventWithLastID
 func (s *publication) LastEventID() string { return s.lastEventID }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -16,21 +16,21 @@ func TestDecode(t *testing.T) {
 	}{
 		{
 			rawInput:     "event: eventName\ndata: {\"sample\":\"value\"}\n\n",
-			wantedEvents: []*publication{{event: "eventName", data: "{\"sample\":\"value\"}"}},
+			wantedEvents: []*publication{newPublicationEvent("", "eventName", "", "{\"sample\":\"value\"}")},
 		},
 		{
 			// the newlines should not be parsed as empty event
 			rawInput:     "\n\n\nevent: event1\n\n\n\n\nevent: event2\n\n",
-			wantedEvents: []*publication{{event: "event1"}, {event: "event2"}},
+			wantedEvents: []*publication{newPublicationEvent("", "event1", "", ""), newPublicationEvent("", "event2", "", "")},
 		},
 		{
 			rawInput:     "id: abc\ndata: def\n\n",
-			wantedEvents: []*publication{{id: "abc", lastEventID: "abc", data: "def"}},
+			wantedEvents: []*publication{newPublicationEvent("abc", "", "abc", "def")},
 		},
 		{
 			// id field should be ignored if it contains a null
 			rawInput:     "id: a\x00bc\ndata: def\n\n",
-			wantedEvents: []*publication{{data: "def"}},
+			wantedEvents: []*publication{newPublicationEvent("", "", "", "def")},
 		},
 	}
 
@@ -65,7 +65,10 @@ func TestDecoderTracksLastEventID(t *testing.T) {
 		event, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "abc", event.Data())
+		evData, err := io.ReadAll(event.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "abc", string(evData))
 		assert.Equal(t, "", event.Id())
 		assert.Equal(t, "my-id", requireLastEventID(t, event))
 	})
@@ -77,21 +80,30 @@ func TestDecoderTracksLastEventID(t *testing.T) {
 		event1, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "first", event1.Data())
+		evData1, err := io.ReadAll(event1.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", string(evData1))
 		assert.Equal(t, "abc", event1.Id())
 		assert.Equal(t, "abc", requireLastEventID(t, event1))
 
 		event2, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "second", event2.Data())
+		evData2, err := io.ReadAll(event2.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", string(evData2))
 		assert.Equal(t, "", event2.Id())
 		assert.Equal(t, "abc", requireLastEventID(t, event2))
 
 		event3, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "third", event3.Data())
+		evData3, err := io.ReadAll(event3.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "third", string(evData3))
 		assert.Equal(t, "def", event3.Id())
 		assert.Equal(t, "def", requireLastEventID(t, event3))
 	})
@@ -103,21 +115,30 @@ func TestDecoderTracksLastEventID(t *testing.T) {
 		event1, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "first", event1.Data())
+		evData1, err := io.ReadAll(event1.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", string(evData1))
 		assert.Equal(t, "abc", event1.Id())
 		assert.Equal(t, "abc", requireLastEventID(t, event1))
 
 		event2, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "second", event2.Data())
+		evData2, err := io.ReadAll(event2.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", string(evData2))
 		assert.Equal(t, "", event2.Id())
 		assert.Equal(t, "abc", requireLastEventID(t, event2))
 
 		event3, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "third", event3.Data())
+		evData3, err := io.ReadAll(event3.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "third", string(evData3))
 		assert.Equal(t, "def", event3.Id())
 		assert.Equal(t, "def", requireLastEventID(t, event3))
 	})
@@ -129,14 +150,20 @@ func TestDecoderTracksLastEventID(t *testing.T) {
 		event1, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "first", event1.Data())
+		evData1, err := io.ReadAll(event1.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "first", string(evData1))
 		assert.Equal(t, "abc", event1.Id())
 		assert.Equal(t, "abc", requireLastEventID(t, event1))
 
 		event2, err := decoder.Decode()
 		require.NoError(t, err)
 
-		assert.Equal(t, "second", event2.Data())
+		evData2, err := io.ReadAll(event2.GetReader())
+		require.NoError(t, err)
+
+		assert.Equal(t, "second", string(evData2))
 		assert.Equal(t, "", event2.Id())
 		assert.Equal(t, "", requireLastEventID(t, event2))
 	})

--- a/encoder.go
+++ b/encoder.go
@@ -1,6 +1,8 @@
 package eventsource
 
 import (
+	"bufio"
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -15,7 +17,6 @@ var (
 	}{
 		{"id: ", Event.Id, false},
 		{"event: ", Event.Event, false},
-		{"data: ", Event.Data, true},
 	}
 )
 
@@ -36,6 +37,111 @@ func NewEncoder(w io.Writer, compressed bool) *Encoder {
 	return &Encoder{w: w}
 }
 
+type streamingNewlineSplitter struct {
+	bufferSize              int
+	hasProcessedData        bool
+	lastEventEndedInNewline bool
+}
+
+func newStreamingNewlineSplitter(bufferSize int) *streamingNewlineSplitter {
+	return &streamingNewlineSplitter{bufferSize: bufferSize}
+
+}
+
+func (s *streamingNewlineSplitter) scan(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// We are at the end of the data stream, and we have no remaining data to process.
+	if atEOF && len(data) == 0 {
+		// If the last event ended with a newline, then we need to return one
+		// final empty segment.
+		//
+		// Alternatively, if we have NEVER processed anything, then we should
+		// ensure we send at least one empty segment.
+		if s.lastEventEndedInNewline || !s.hasProcessedData {
+			s.lastEventEndedInNewline = false
+			s.hasProcessedData = true
+			return 0, []byte(""), nil
+		}
+
+		return 0, nil, nil
+	}
+
+	// If the current block has a newline, then we can return that as a block.
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		s.hasProcessedData = true
+		s.lastEventEndedInNewline = true
+		return i + 1, data[0 : i+1], nil
+	}
+
+	// There is no guarantee that the data will every contain a new line. So we
+	// set a limit on the number of bytes we can process before we return a
+	// payload.
+	if len(data) >= s.bufferSize {
+		s.hasProcessedData = true
+		return len(data), data, nil
+	}
+
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		s.hasProcessedData = true
+		return len(data), data, nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
+}
+
+type sseStreamingWriter struct {
+	writer     io.Writer
+	bufferSize int
+}
+
+func (s *sseStreamingWriter) Write(p []byte) (n int, err error) {
+	reader := bytes.NewReader(p)
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(newStreamingNewlineSplitter(s.bufferSize).scan)
+
+	startNewEvent := true
+	processed := 0
+
+	for scanner.Scan() {
+		// This scan text may include a newline if it was split on that
+		// boundary, or it might not, if it was returned due to buffer
+		// limit constraints.
+		//
+		// If there isn't a newline, then we can continue streaming it as
+		// part of the current event. Otherwise, we need to start a new
+		// event.
+		text := scanner.Text()
+		if startNewEvent {
+			if _, err := io.WriteString(s.writer, "data: "); err != nil {
+				return processed, fmt.Errorf("eventsource encode: %v", err)
+			}
+		}
+
+		bytesWritten, err := io.WriteString(s.writer, text)
+		if err != nil {
+			return processed, fmt.Errorf("eventsource encode: %v", err)
+		}
+
+		processed += bytesWritten
+
+		startNewEvent = strings.HasSuffix(text, "\n")
+	}
+
+	// If the final block didn't end in a newline, we need to ensure we write a final one.
+	if !startNewEvent {
+		if _, err := io.WriteString(s.writer, "\n"); err != nil {
+			return processed, fmt.Errorf("eventsource encode: %v", err)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return processed, fmt.Errorf("eventsource encode: %v", err)
+	}
+
+	return processed, nil
+}
+
 // Encode writes an event or comment in the format specified by the
 // server-sent events protocol.
 func (enc *Encoder) Encode(ec eventOrComment) error {
@@ -46,6 +152,7 @@ func (enc *Encoder) Encode(ec eventOrComment) error {
 			if len(value) == 0 && !field.required {
 				continue
 			}
+
 			for _, s := range strings.Split(value, "\n") {
 				if _, err := io.WriteString(enc.w, prefix); err != nil {
 					return fmt.Errorf("eventsource encode: %v", err)
@@ -58,6 +165,19 @@ func (enc *Encoder) Encode(ec eventOrComment) error {
 				}
 			}
 		}
+
+		written, err := io.Copy(&sseStreamingWriter{writer: enc.w, bufferSize: 1_000}, item.GetReader())
+		if err != nil {
+			return err
+		}
+
+		if written == 0 {
+			if _, err := io.WriteString(enc.w, "data: \n"); err != nil {
+				return fmt.Errorf("eventsource encode: %v", err)
+			}
+		}
+
+		// Every payload ends with a newline.
 		if _, err := io.WriteString(enc.w, "\n"); err != nil {
 			return fmt.Errorf("eventsource encode: %v", err)
 		}

--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -1,11 +1,14 @@
 package eventsource_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/launchdarkly/eventsource"
+	"io"
 	"net"
 	"net/http"
+
+	"github.com/launchdarkly/eventsource"
 )
 
 type NewsArticle struct {
@@ -13,14 +16,22 @@ type NewsArticle struct {
 	Title, Content string
 }
 
-func (a *NewsArticle) Id() string    { return a.id }
-func (a *NewsArticle) Event() string { return "News Article" }
-func (a *NewsArticle) Data() string  { b, _ := json.Marshal(a); return string(b) }
+func NewNewsArticle(id, title, content string) *NewsArticle {
+	return &NewsArticle{
+		id:      id,
+		Title:   title,
+		Content: content,
+	}
+}
+
+func (a *NewsArticle) Id() string           { return a.id }
+func (a *NewsArticle) Event() string        { return "News Article" }
+func (a *NewsArticle) GetReader() io.Reader { b, _ := json.Marshal(a); return bytes.NewReader(b) }
 
 var articles = []NewsArticle{
-	{"2", "Governments struggle to control global price of gas", "Hot air...."},
-	{"1", "Tomorrow is another day", "And so is the day after."},
-	{"3", "News for news' sake", "Nothing has happened."},
+	*NewNewsArticle("2", "Governments struggle to control global price of gas", "Hot air...."),
+	*NewNewsArticle("1", "Tomorrow is another day", "And so is the day after."),
+	*NewNewsArticle("3", "News for news' sake", "Nothing has happened."),
 }
 
 func buildRepo(srv *eventsource.Server) {
@@ -50,7 +61,10 @@ func ExampleRepository() {
 	// This will receive events in the order that they come
 	for i := 0; i < 3; i++ {
 		ev := <-stream.Events
-		fmt.Println(ev.Id(), ev.Event(), ev.Data())
+		evData, err := io.ReadAll(ev.GetReader())
+		if err == nil {
+			fmt.Println(ev.Id(), ev.Event(), string(evData))
+		}
 	}
 	stream, err = eventsource.Subscribe("http://127.0.0.1:8080/articles", "1")
 	if err != nil {
@@ -60,7 +74,10 @@ func ExampleRepository() {
 	// This will replay the events in order of id
 	for i := 0; i < 3; i++ {
 		ev := <-stream.Events
-		fmt.Println(ev.Id(), ev.Event(), ev.Data())
+		evData, err := io.ReadAll(ev.GetReader())
+		if err == nil {
+			fmt.Println(ev.Id(), ev.Event(), string(evData))
+		}
 	}
 	// Output:
 	// 2 News Article {"Title":"Governments struggle to control global price of gas","Content":"Hot air...."}

--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,10 @@
 // If the Repository interface is implemented on the server, events can be replayed in case of a network disconnection.
 package eventsource
 
+import (
+	"io"
+)
+
 // Event is the interface for any event received by the client or sent by the server.
 type Event interface {
 	// Id is an identifier that can be used to allow a client to replay
@@ -13,8 +17,11 @@ type Event interface {
 	Id() string
 	// The name of the event. Return empty string if not required.
 	Event() string
-	// The payload of the event.
-	Data() string
+	// A reader that will return the payload of the event.
+	//
+	// It is expected that this method will return a fresh reader each time,
+	// allowing an event to be read multiple times.
+	GetReader() io.Reader
 }
 
 // EventWithLastID is an additional interface for an event received by the client,

--- a/server_test.go
+++ b/server_test.go
@@ -22,7 +22,7 @@ func (r *testServerRepository) Replay(channel, id string) chan Event {
 	} else {
 		fakeID = "replayed-from-" + id
 	}
-	out <- &publication{id: fakeID, data: "example"}
+	out <- newPublicationEvent(fakeID, "", "", "example")
 	close(out)
 	return out
 }
@@ -66,7 +66,7 @@ func TestServerHandlerReceivesPublishedEvents(t *testing.T) {
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 
-	event := &publication{data: "my-event"}
+	event := newPublicationEvent("", "", "", "my-event")
 	ackCh := server.PublishWithAcknowledgment([]string{channel}, event)
 	<-ackCh
 	server.Close()
@@ -94,7 +94,7 @@ func TestServerHandlerReceivesPublishedComments(t *testing.T) {
 	defer resp2.Body.Close()
 
 	server.PublishComment([]string{channel}, "my comment")
-	event := &publication{data: "my-event"}
+	event := newPublicationEvent("", "", "", "my-event")
 	ackCh := server.PublishWithAcknowledgment([]string{channel}, event)
 	<-ackCh
 	server.Close()
@@ -207,12 +207,12 @@ func TestServerCanDisconnectClientsWhenUnregisteringRepository(t *testing.T) {
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 
-	event1 := &publication{data: "my-event1"}
+	event1 := newPublicationEvent("", "", "", "my-event1")
 	ackCh := server.PublishWithAcknowledgment([]string{channel}, event1)
 	<-ackCh
 	server.Unregister(channel, true)
 
-	event2 := &publication{data: "my-event2"}
+	event2 := newPublicationEvent("", "", "", "my-event2")
 	ackCh = server.PublishWithAcknowledgment([]string{channel}, event2)
 	<-ackCh
 

--- a/stream_restart_close_test.go
+++ b/stream_restart_close_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func toPublication(e httphelpers.SSEEvent) *publication {
-	return &publication{
-		id:    e.ID,
-		event: e.Event,
-		data:  e.Data,
-	}
+	return newPublicationEvent(e.ID, e.Event, "", e.Data)
 }
 
 func TestStreamRestart(t *testing.T) {


### PR DESCRIPTION
Requiring a string for the event payload necessitates keeping the entire payload event in memory. It would be better from a memory-usage POV if we could stream the data via an io.Reader.

While the interface in this package is changing, the reading and parsing behavior isn't. In other words, any event generated by this library (at least for now), is still reading the entire event payload into memory when it comes across the wire.

However, this change enables the LaunchDarkly SDK to create an event from within our relay proxy which takes advantage of streaming, thereby reducing the memory footprint of that application quite a lot.