### PR TITLE
Support encoding comments by exposing the type

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -47,9 +47,8 @@ func TestEncodeComment(t *testing.T) {
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf, false)
 	text := "This is a comment"
-	comm := comment{value: "This is a comment"}
 	expected := ":" + text + "\n"
-	if err := enc.Encode(comm); err != nil {
+	if err := enc.Encode(Comment(text)); err != nil {
 		t.Fatal(err)
 	}
 	if buf.String() != expected {

--- a/encoder.go
+++ b/encoder.go
@@ -61,8 +61,8 @@ func (enc *Encoder) Encode(ec eventOrComment) error {
 		if _, err := io.WriteString(enc.w, "\n"); err != nil {
 			return fmt.Errorf("eventsource encode: %v", err)
 		}
-	case comment:
-		line := ":" + item.value + "\n"
+	case Comment:
+		line := ":" + string(item) + "\n"
 		if _, err := io.WriteString(enc.w, line); err != nil {
 			return fmt.Errorf("eventsource encode: %v", err)
 		}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -60,7 +60,7 @@ func TestEncoderMultiLineData(t *testing.T) {
 
 func TestEncoderComment(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	c := comment{value: "hello"}
+	c := Comment("hello")
 	NewEncoder(buf, false).Encode(c)
 	assert.Equal(t, ":hello\n", string(buf.Bytes()))
 }

--- a/server.go
+++ b/server.go
@@ -31,9 +31,7 @@ type unregistration struct {
 	forceDisconnect bool
 }
 
-type comment struct {
-	value string
-}
+type Comment string
 
 type eventBatch struct {
 	events <-chan Event
@@ -243,10 +241,10 @@ func (srv *Server) PublishWithAcknowledgment(channels []string, ev Event) <-chan
 }
 
 // PublishComment publishes a comment to one or more channels.
-func (srv *Server) PublishComment(channels []string, text string) {
+func (srv *Server) PublishComment(channels []string, text Comment) {
 	srv.pub <- &outbound{
 		channels:       channels,
-		eventOrComment: comment{value: text},
+		eventOrComment: text,
 	}
 }
 


### PR DESCRIPTION
Prior to this it was not possible to publish comments using the
encoder
