### PR TITLE
fix: prevent stream shutdown deadlock when Close races with event delivery

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -322,13 +322,25 @@ NewStream:
 			if r != nil {
 				_ = r.Close()
 				r = nil
-				// allow the decoding goroutine to terminate
-				//nolint:revive // false positive, need to drain the channels here
-				for range errs {
-				}
-				//nolint:revive // false positive, need to drain the channels here
-				for range events {
-				}
+				// Allow the decoding goroutine to terminate. After r.Close it will either return an
+				// error from Decode (sending on errs, then closing both channels) or, if it had
+				// already decoded an event, still be blocked sending that event on events. We must
+				// therefore drain both channels concurrently: draining them sequentially deadlocks
+				// if the goroutine is blocked sending on the one we are not yet reading (e.g. we
+				// wait on errs while it is stuck on events), and neither side can make progress.
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					for range errs { //nolint:revive // draining until the channel is closed
+					}
+				}()
+				go func() {
+					defer wg.Done()
+					for range events { //nolint:revive // draining until the channel is closed
+					}
+				}()
+				wg.Wait()
 			}
 		}
 

--- a/stream_close_during_delivery_test.go
+++ b/stream_close_during_delivery_test.go
@@ -1,0 +1,62 @@
+package eventsource
+
+import (
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-test-helpers/v3/httphelpers"
+)
+
+// TestStreamCloseDuringEventDeliveryDoesNotDeadlock is a regression test for a deadlock in the
+// stream goroutine's shutdown path (discardCurrentStream). When Close raced with an event that had
+// just been decoded, discardCurrentStream drained the internal errs channel before events while the
+// decoder goroutine was blocked sending on events, so neither side progressed and stream.Events was
+// never closed. A consumer ranging over stream.Events to drain it on shutdown would then hang
+// forever. See discardCurrentStream in stream.go.
+//
+// The race is timing-dependent, so this floods the stream and closes mid-delivery, repeated many
+// times to make the interleaving overwhelmingly likely. On regression the consumer's drain never
+// finishes and the test times out, printing all goroutines to pinpoint the block.
+func TestStreamCloseDuringEventDeliveryDoesNotDeadlock(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		func() {
+			streamHandler, streamControl := httphelpers.SSEHandler(nil)
+			defer streamControl.Close()
+			httpServer := httptest.NewServer(streamHandler)
+			defer httpServer.Close()
+
+			stream := mustSubscribe(t, httpServer.URL)
+
+			// Flood the stream so the decoder is very likely mid-delivery of an event when we Close.
+			go func() {
+				for j := 0; j < 500; j++ {
+					streamControl.Enqueue(httphelpers.SSEEvent{ID: "id", Data: "data"})
+				}
+			}()
+
+			// A real consumer drains Events (and Errors) until they close on shutdown; that only
+			// happens once the stream goroutine exits cleanly, so this is what deadlocked.
+			drained := make(chan struct{})
+			go func() {
+				for range stream.Events {
+				}
+				for range stream.Errors {
+				}
+				close(drained)
+			}()
+
+			time.Sleep(2 * time.Millisecond)
+			stream.Close()
+
+			select {
+			case <-drained:
+			case <-time.After(5 * time.Second):
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				t.Fatalf("stream.Events was never closed after Close (deadlock) on iteration %d\n%s", i, buf[:n])
+			}
+		}()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a deadlock in the stream goroutine's shutdown path that can leave `stream.Events` permanently open. A consumer that drains `stream.Events` after calling `Close` (the documented shutdown pattern) then hangs forever.

## Background

When the stream is torn down — via `Close`, `Restart`, or a read error — `discardCurrentStream` shuts down the current connection's decoder goroutine and drains its two internal channels so the goroutine can exit:

```go
_ = r.Close()
r = nil
for range errs {   // drain errs first...
}
for range events { // ...then events
}
```

The decoder goroutine is a simple loop: decode, and either send the event on `events`, or on error send on `errs` and close both channels.

```go
for {
    ev, err := dec.Decode()
    if err != nil {
        errs <- err
        close(errs)
        close(events)
        return
    }
    events <- ev
}
```

The drain assumes that after `r.Close()` the decoder is (or will shortly be) in the error path, so draining `errs` first lets it reach the `close(errs); close(events)`. But if the decoder had **already** decoded an event and was blocked on `events <- ev` when we closed, `r.Close()` doesn't unblock it — it's parked on a send, not inside `Decode`. The drain waits on `errs` (nothing will ever arrive there), and the decoder waits for someone to receive its `events` send. Neither moves, so `events`/`errs` are never closed, `stream.stream` never reaches `close(stream.Events)`, and any consumer ranging over `stream.Events` on shutdown blocks forever.

It's timing-dependent — it needs `Close` to land while an event is mid-delivery — so it shows up as a rare, intermittent hang. It surfaced downstream in `ld-relay`'s auto-config stream (relay shutdown intermittently hanging until the process/test timed out).

## Fix

Drain both internal channels **concurrently**. The decoder can be blocked sending on either one, and once unblocked it always closes both — so draining them together lets it terminate regardless of which send it was parked on.

```go
_ = r.Close()
r = nil
var wg sync.WaitGroup
wg.Add(2)
go func() { defer wg.Done(); for range errs { } }()   // may be blocked here
go func() { defer wg.Done(); for range events { } }()  // ...or here
wg.Wait()
```

## Verification

- New regression test `TestStreamCloseDuringEventDeliveryDoesNotDeadlock` floods the stream and closes mid-delivery, repeatedly. It **hangs → fails** on the old code (deadlock stack in `discardCurrentStream`) and **passes** with the fix.
- Full suite green under `-race`: `go test -race ./...`.
- Validated end-to-end against `ld-relay`: with this fix pulled in via a local `replace` and **no** changes to `ld-relay`, its auto-config shutdown regression test passes; against stock v1.11.0 the same test hangs.
