### PR TITLE
ci: Add explicit permissions for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- Add a job-level `permissions: { contents: write, pull-requests: write }` block to `.github/workflows/release-please.yml`, mirroring the `create-prs` job in `.github/workflows/check-go-versions.yml`.

## Background
The **Run Release Please** workflow started failing with a 403 after merging #60:
```
✖ Error when creating branch
✖ RequestError [HttpError]: Error creating Pull Request: Resource not accessible by integration
   status: 403
```
The job had no `permissions:` block, so its `GITHUB_TOKEN` was read-only under the (now-tightened) default, and `release-please-action` couldn't create the release branch or PR. This blocked cutting v1.11.1, which contains the stream-close deadlock fix from #60.
